### PR TITLE
[CHORE-32] Redis Setup cho OTP + Token Blacklist

### DIFF
--- a/BazanAI/infra/docker-compose.yml
+++ b/BazanAI/infra/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   redis:
     image: redis:7.2-alpine
     container_name: redis
-    command: redis-server --requirepass ${REDIS_PASSWORD:-bazan_redis_password}
+    command: redis-server --requirepass ${REDIS_PASSWORD:-bazan_redis_password} --maxmemory 256mb --maxmemory-policy allkeys-lru
     ports:
       - 6379:6379
     volumes:


### PR DESCRIPTION
## Changes
- Updated Redis configuration in `docker-compose.yml` with `--maxmemory 256mb` and `--maxmemory-policy allkeys-lru`.

## Checklist
- [x] AC-I2-03: Maxmemory policy configured.