### PR TITLE
[FEAT-34] MongoDB Indexes cho Identity Collections

### DIFF
--- a/BazanAI/infra/mongo-init/sprint-2-indexes.js
+++ b/BazanAI/infra/mongo-init/sprint-2-indexes.js
@@ -1,19 +1,22 @@
 // bazan_identity.farmers
+// Chú ý: Cần đồng bộ PascalCase/camelCase với Domain model và MongoDB driver configuration.
+// Theo ADR-001 và yêu cầu issue #34, chúng ta sử dụng camelCase cho fields trong MongoDB.
+
 db.farmers.createIndex(
-  { "Identities.Provider": 1, "Identities.ProviderUserId": 1 },
+  { "identities.provider": 1, "identities.providerUserId": 1 },
   { unique: true, sparse: true, name: "idx_identity_provider_unique" }
 );
 db.farmers.createIndex({ "location.coordinates": "2dsphere" }, { name: "idx_location_geo" });
-db.farmers.createIndex({ "CreatedAt": 1 }, { name: "idx_created_at" });
+db.farmers.createIndex({ "createdAt": 1 }, { name: "idx_created_at" });
 
 // bazan_identity.farms
-db.farms.createIndex({ "FarmerId": 1 }, { name: "idx_farmer_id" });
+db.farms.createIndex({ "farmerId": 1 }, { name: "idx_farmer_id" });
 db.farms.createIndex({ "location.coordinates": "2dsphere" }, { name: "idx_farm_geo" });
 
 // bazan_identity.user_contexts
-db.user_contexts.createIndex({ "FarmerId": 1 }, { unique: true, name: "idx_farmer_id_unique" });
+db.user_contexts.createIndex({ "farmerId": 1 }, { unique: true, name: "idx_farmer_id_unique" });
 
 // bazan_identity.refresh_tokens
-db.refresh_tokens.createIndex({ "HashedToken": 1 }, { name: "idx_hashed_token" });
-db.refresh_tokens.createIndex({ "FarmerId": 1, "IsRevoked": 1 }, { name: "idx_farmer_active" });
-db.refresh_tokens.createIndex({ "ExpiresAt": 1 }, { expireAfterSeconds: 0, name: "idx_ttl_expire" });
+db.refresh_tokens.createIndex({ "hashedToken": 1 }, { name: "idx_hashed_token" });
+db.refresh_tokens.createIndex({ "farmerId": 1, "isRevoked": 1 }, { name: "idx_farmer_active" });
+db.refresh_tokens.createIndex({ "expiresAt": 1 }, { expireAfterSeconds: 0, name: "idx_ttl_expire" });


### PR DESCRIPTION
## Changes
- Updated `BazanAI/infra/mongo-init/sprint-2-indexes.js` with mandatory indexes for:
  - `farmers`: Identity unique constraint, 2dsphere geo index, createdAt index.
  - `farms`: farmerId index, 2dsphere geo index.
  - `user_contexts`: farmerId unique index.
  - `refresh_tokens`: hashedToken, active tokens, and TTL (ExpiresAt) index.

## Checklist
- [x] Fields follow camelCase as per issue #34 requirements.
- [x] TTL index for refresh tokens added.