### PR TITLE
[FEAT-19] AES-256-GCM Encryption Service

### DIFF
--- a/BazanAI/infra/.env.example
+++ b/BazanAI/infra/.env.example
@@ -27,6 +27,7 @@ ACCEPT_EULA=Y
 # ==========================================
 JWT_SECRET=bazan_ai_very_long_and_secure_jwt_secret_key_2026
 JWT_EXPIRY_HOURS=24
+PII_ENCRYPTION_KEY=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f # 32-byte hex key
 
 # External APIs (Placeholders)
 # ==========================================

--- a/BazanAI/src/SharedKernel/BazanAI.Infrastructure.Common/DependencyInjection.cs
+++ b/BazanAI/src/SharedKernel/BazanAI.Infrastructure.Common/DependencyInjection.cs
@@ -5,11 +5,19 @@ using BazanAI.SharedKernel.Events;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using BazanAI.Infrastructure.Common.Security;
+using BazanAI.SharedKernel.Security;
 
 namespace BazanAI.Infrastructure.Common;
 
 public static class DependencyInjection
 {
+    public static IServiceCollection AddBazanSecurity(this IServiceCollection services)
+    {
+        services.AddSingleton<IPiiEncryptionService, AesGcmPiiEncryptionService>();
+        return services;
+    }
+
     public static IServiceCollection AddBazanMassTransit(
         this IServiceCollection services, 
         IConfiguration configuration,

--- a/BazanAI/src/SharedKernel/BazanAI.Infrastructure.Common/Security/AesGcmPiiEncryptionService.cs
+++ b/BazanAI/src/SharedKernel/BazanAI.Infrastructure.Common/Security/AesGcmPiiEncryptionService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using BazanAI.SharedKernel.Security;
+using Microsoft.Extensions.Configuration;
+
+namespace BazanAI.Infrastructure.Common.Security;
+
+public class AesGcmPiiEncryptionService : IPiiEncryptionService
+{
+    private readonly byte[] _key;
+    private const int NonceSize = 12; // 96 bits for GCM
+    private const int TagSize = 16;   // 128 bits for GCM
+
+    public AesGcmPiiEncryptionService(IConfiguration configuration)
+    {
+        var keyHex = configuration["PII_ENCRYPTION_KEY"];
+        if (string.IsNullOrWhiteSpace(keyHex))
+        {
+            throw new InvalidOperationException("PII_ENCRYPTION_KEY is not configured in environment variables.");
+        }
+
+        try
+        {
+            _key = Convert.FromHexString(keyHex);
+            if (_key.Length != 32)
+            {
+                throw new InvalidOperationException("PII_ENCRYPTION_KEY must be a 32-byte hex string (64 characters).");
+            }
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException("PII_ENCRYPTION_KEY must be a valid hex string.", ex);
+        }
+    }
+
+    public string Encrypt(string plaintext)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return plaintext;
+
+        byte[] nonce = new byte[NonceSize];
+        RandomNumberGenerator.Fill(nonce);
+
+        byte[] inputBytes = Encoding.UTF8.GetBytes(plaintext);
+        byte[] ciphertext = new byte[inputBytes.Length];
+        byte[] tag = new byte[TagSize];
+
+        using var aesGcm = new AesGcm(_key, TagSize);
+        aesGcm.Encrypt(nonce, inputBytes, ciphertext, tag);
+
+        // Format: Base64(Nonce || Ciphertext || Tag)
+        byte[] result = new byte[NonceSize + ciphertext.Length + TagSize];
+        Buffer.BlockCopy(nonce, 0, result, 0, NonceSize);
+        Buffer.BlockCopy(ciphertext, 0, result, NonceSize, ciphertext.Length);
+        Buffer.BlockCopy(tag, 0, result, NonceSize + ciphertext.Length, TagSize);
+
+        return Convert.ToBase64String(result);
+    }
+
+    public string Decrypt(string ciphertext)
+    {
+        if (string.IsNullOrEmpty(ciphertext)) return ciphertext;
+
+        try
+        {
+            byte[] fullBytes = Convert.FromBase64String(ciphertext);
+
+            if (fullBytes.Length < NonceSize + TagSize)
+            {
+                throw new CryptographicException("Invalid ciphertext length.");
+            }
+
+            byte[] nonce = new byte[NonceSize];
+            byte[] tag = new byte[TagSize];
+            int ciphertextLength = fullBytes.Length - NonceSize - TagSize;
+            byte[] cipherBytes = new byte[ciphertextLength];
+
+            Buffer.BlockCopy(fullBytes, 0, nonce, 0, NonceSize);
+            Buffer.BlockCopy(fullBytes, NonceSize, cipherBytes, 0, ciphertextLength);
+            Buffer.BlockCopy(fullBytes, NonceSize + ciphertextLength, tag, 0, TagSize);
+
+            byte[] decryptedBytes = new byte[ciphertextLength];
+
+            using var aesGcm = new AesGcm(_key, TagSize);
+            aesGcm.Decrypt(nonce, cipherBytes, tag, decryptedBytes);
+
+            return Encoding.UTF8.GetString(decryptedBytes);
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException)
+        {
+            // Log warning here in a real scenario
+            throw new CryptographicException("Decryption failed. The data might be tampered or the key is incorrect.", ex);
+        }
+    }
+}

--- a/BazanAI/src/SharedKernel/BazanAI.SharedKernel/Security/IPiiEncryptionService.cs
+++ b/BazanAI/src/SharedKernel/BazanAI.SharedKernel/Security/IPiiEncryptionService.cs
@@ -1,0 +1,26 @@
+namespace BazanAI.SharedKernel.Security;
+
+/// <summary>
+/// Service for encrypting and decrypting Personally Identifiable Information (PII) 
+/// before storing it in the database.
+/// Uses AES-256-GCM for authenticated encryption.
+/// </summary>
+public interface IPiiEncryptionService
+{
+    /// <summary>
+    /// Encrypts the given plaintext using AES-256-GCM.
+    /// Returns a Base64 string of the format: Base64(IV || Ciphertext || Tag)
+    /// </summary>
+    /// <param name="plaintext">The text to encrypt</param>
+    /// <returns>Base64 encoded encrypted string</returns>
+    string Encrypt(string plaintext);
+
+    /// <summary>
+    /// Decrypts the given ciphertext.
+    /// Expects a Base64 string of the format: Base64(IV || Ciphertext || Tag)
+    /// </summary>
+    /// <param name="ciphertext">The Base64 encoded encrypted string</param>
+    /// <returns>Original plaintext string</returns>
+    /// <exception cref="System.Security.Cryptography.CryptographicException">Thrown if decryption or authentication fails</exception>
+    string Decrypt(string ciphertext);
+}

--- a/BazanAI/tests/Unit/BazanAI.Infrastructure.Common.Tests/Security/PiiEncryptionTests.cs
+++ b/BazanAI/tests/Unit/BazanAI.Infrastructure.Common.Tests/Security/PiiEncryptionTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using BazanAI.Infrastructure.Common.Security;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Xunit;
+
+namespace BazanAI.Infrastructure.Common.Tests.Security;
+
+public class PiiEncryptionTests
+{
+    private readonly AesGcmPiiEncryptionService _sut;
+    private const string TestKeyHex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"; // 32 bytes
+
+    public PiiEncryptionTests()
+    {
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["PII_ENCRYPTION_KEY"].Returns(TestKeyHex);
+        _sut = new AesGcmPiiEncryptionService(configuration);
+    }
+
+    [Fact]
+    public void Encrypt_WhenValidPlaintext_ReturnsBase64String()
+    {
+        // Arrange
+        var plaintext = "Hello Bazan AI";
+
+        // Act
+        var ciphertext = _sut.Encrypt(plaintext);
+
+        // Assert
+        ciphertext.Should().NotBeNullOrEmpty();
+        Action act = () => Convert.FromBase64String(ciphertext);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Decrypt_WhenValidCiphertext_ReturnsOriginalPlaintext()
+    {
+        // Arrange
+        var original = "Sieu bao bao ve nong dan";
+        var encrypted = _sut.Encrypt(original);
+
+        // Act
+        var decrypted = _sut.Decrypt(encrypted);
+
+        // Assert
+        decrypted.Should().Be(original);
+    }
+
+    [Fact]
+    public void Encrypt_ReturnsDifferentCiphertextForSamePlaintext()
+    {
+        // Arrange
+        var plaintext = "Same Text";
+
+        // Act
+        var cipher1 = _sut.Encrypt(plaintext);
+        var cipher2 = _sut.Encrypt(plaintext);
+
+        // Assert
+        cipher1.Should().NotBe(cipher2); // Due to random Nonce/IV
+    }
+
+    [Fact]
+    public void Decrypt_WhenCiphertextIsTampered_ThrowsCryptographicException()
+    {
+        // Arrange
+        var plaintext = "Secret Data";
+        var ciphertextBase64 = _sut.Encrypt(plaintext);
+        byte[] cipherBytes = Convert.FromBase64String(ciphertextBase64);
+        
+        // Flip a bit in the ciphertext part (after 12 bytes of nonce)
+        cipherBytes[15] ^= 0xFF; 
+        var tamperedCiphertext = Convert.ToBase64String(cipherBytes);
+
+        // Act
+        Action act = () => _sut.Decrypt(tamperedCiphertext);
+
+        // Assert
+        act.Should().Throw<CryptographicException>()
+           .WithMessage("Decryption failed*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Encrypt_WhenNullOrEmpty_ReturnsSame(string? input)
+    {
+        // Act
+        var result = _sut.Encrypt(input!);
+
+        // Assert
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void Constructor_WhenKeyIsMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["PII_ENCRYPTION_KEY"].Returns((string?)null);
+
+        // Act
+        Action act = () => new AesGcmPiiEncryptionService(configuration);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*not configured*");
+    }
+
+    [Fact]
+    public void Constructor_WhenKeyIsInvalidLength_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["PII_ENCRYPTION_KEY"].Returns("1234"); // Too short
+
+        // Act
+        Action act = () => new AesGcmPiiEncryptionService(configuration);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*32-byte hex string*");
+    }
+}


### PR DESCRIPTION
## Changes
- Implemented `IPiiEncryptionService` using AES-256-GCM for authenticated encryption.
- Added `AesGcmPiiEncryptionService` in Infrastructure.Common.
- Registered service in DI via `AddBazanSecurity()`.
- Added unit tests verifying encryption/decryption and tampering detection.
- Updated `.env.example` with `PII_ENCRYPTION_KEY`.

## Checklist
- [x] AC-P1-01: IV is random per encryption.
- [x] AC-P1-04: Tampering detected (throws exception).
- [x] AC-P1-05: Key is not hardcoded.