### PR TITLE
[FEAT-11] OTP Service: Gửi qua Zalo OA

### DIFF
--- a/BazanAI/docs/product-business/product-roadmap.md
+++ b/BazanAI/docs/product-business/product-roadmap.md
@@ -1,112 +1,629 @@
 # Product Roadmap — Bazan AI
-## Agentic Microservices Platform for Coffee Farmers
+## Agentic Microservices Platform · Coffee Farmers Tây Nguyên
 
-| Thông tin | Giá trị |
-|-----------|---------|
-| **Phiên bản** | 1.1.0 (Enterprise Grade) |
+| Trường | Nội dung |
+|--------|---------|
+| **Phiên bản** | 1.2.0 |
 | **Ngày cập nhật** | 2026-03-19 |
-| **Trạng thái** | Draft - Approved for Phase 1 |
-| **Tiêu chuẩn** | IBM/Enterprise Architecture |
+| **Trạng thái** | Active — Sprint 1 Completed |
+| **Tiêu chuẩn** | Enterprise Architecture · Clean Architecture |
+| **Thay đổi so với v1.1** | Swap Sprint 6↔7 · Tách Sprint 3 → 3a/3b · Thêm CV Detection · Security Audit · WASI Prep |
 
 ---
 
-## 1. Tầm nhìn Chiến lược (Strategic Vision)
-Xây dựng một hệ thống hỗ trợ nông nghiệp thông minh, bảo mật và bền bỉ, giúp nông dân Tây Nguyên tối ưu hóa quy trình canh tác và kinh tế thông qua dữ liệu thực địa và trí tuệ nhân tạo (Agentic AI).
+## 1. Tầm nhìn Chiến lược
+
+Xây dựng nền tảng AI hỗ trợ nông nghiệp thông minh, bảo mật và bền bỉ — giúp **600.000 nông dân trồng cà phê Tây Nguyên** tối ưu hóa canh tác và quyết định kinh tế thông qua dữ liệu thực địa và Agentic AI.
+
+**North Star Metric:** Số nông dân nhận được giá trị thực từ Bazan AI mỗi tuần (WAVU — Weekly Active Value Users), đo bằng ≥ 1 session có thumbs-up trong 7 ngày.
 
 ---
 
-## 2. Các Giai đoạn Phát triển (Phases)
+## 2. Các Giai đoạn Phát triển
 
-### Giai đoạn 1: Nền tảng & Bảo mật (Foundation & Security)
-*   Thiết lập hạ tầng Microservices, xác thực và quyền sở hữu dữ liệu (Data Sovereignty).
-*   **KPI:** Hệ thống lõi sẵn sàng, 100% dữ liệu nhạy cảm được mã hóa.
-
-### Giai đoạn 2: Chất lượng Dữ liệu & IoT (Data Quality & IoT)
-*   Kết nối cảm biến hiện trường, làm sạch dữ liệu rác (Data Validation) và hỗ trợ Offline-first.
-*   **KPI:** Độ chính xác dữ liệu cảm biến > 95%, hoạt động được ở vùng sóng yếu.
-
-### Giai đoạn 3: Trí tuệ Nhân tạo & Tri thức (AI & Knowledge)
-*   Kích hoạt Agentic AI với Semantic Kernel và RAG (Retrieval-Augmented Generation).
-*   **KPI:** Phản hồi AI chính xác > 85% dựa trên tài liệu kỹ thuật nông nghiệp.
-
-### Giai đoạn 4: Kinh tế & Thông báo (Economics & Notifications)
-*   Tích hợp dữ liệu thị trường, tính toán ROI và thông báo đa kênh (Zalo/FCM/SMS).
-*   **KPI:** Cung cấp thông tin giá thời gian thực với độ trễ < 5 phút.
+| Giai đoạn | Timeline | Mục tiêu | KPI chính |
+|---------|---------|---------|----------|
+| **Phase 1** — Foundation & Security | Tháng 1–3 | Hạ tầng lõi, xác thực, data sovereignty | 100 farmers pilot, uptime 99.5% |
+| **Phase 2** — Data Quality & IoT | Tháng 4–6 | Cảm biến thực địa, offline-first, DQA | Sensor accuracy > 95%, hoạt động ở 3G |
+| **Phase 3** — AI & Knowledge | Tháng 7–9 | Agentic AI, RAG, disease CV | AI accuracy > 85%, Recall@5 ≥ 0.85 |
+| **Phase 4** — Economics & Scale | Tháng 10–12 | Market data, ROI, notifications, 5.000 farmers | Price latency < 5 phút, D30 retention ≥ 40% |
 
 ---
 
-## 3. Kế hoạch Sprint Chi tiết (12 Sprints)
+## 3. Hoạt động Chuẩn bị (Trước Sprint 2)
 
-### Sprint 1: Infrastructure & Shared Kernel
-*   Thiết lập CI/CD Pipelines, Shared Kernel (.NET/Python).
-*   Cấu hình API Gateway (YARP) cơ bản.
+> **Quan trọng:** Các việc này phải thực hiện **song song với Sprint 2**, không phải chờ đến sprint liên quan. Thiếu chuẩn bị sẽ block Sprint 7 và Sprint 12.
 
-### Sprint 2: Identity, Privacy & Data Sovereignty
-*   Xác thực OTP (Zalo/SMS), JWT.
-*   Mã hóa PII (AES-256) và thiết lập cơ chế Consent Management (Quyền đồng ý của nông dân).
+### 3.1 WASI Partnership — Bắt đầu ngay tuần này
 
-### Sprint 3: Resilient Messaging & Notifications
-*   Triển khai Outbox Pattern cho RabbitMQ để đảm bảo tin nhắn không bị mất.
-*   Tích hợp Zalo OA API & Template Engine.
+```
+Tuần 1:  Soạn email → gửi đề xuất MOU cho WASI (Viện Nghiên cứu Tây Nguyên)
+Tuần 2:  Họp khởi động với WASI — xác định 50 tài liệu ưu tiên
+Tuần 3+: Nhận tài liệu → metadata annotation → chuẩn bị index
 
-### Sprint 4: IoT Ingestion & Data Quality Assurance (DQA)
-*   MQTT Broker & Sensor Topic Router.
-*   Lớp lọc dữ liệu nhiễu (Validation Layer), lọc GPS (Kalman Filter).
-*   Cơ chế Dead Letter Queue (DLQ) cho dữ liệu lỗi.
+Deliverable cần có trước Sprint 7:
+  - ≥ 30 tài liệu WASI (PDF) đã được annotate metadata
+  - ≥ 20 tài liệu WCR (Open Access) đã download
+  - 1 cán bộ WASI làm reviewer cho Golden Test Set
+  - Danh mục thuốc BVTV 2024 (Bộ NN&PTNT) đã có
+```
 
-### Sprint 5: Offline-first Architecture
-*   Chiến lược Local Persistence (SQLite) trên thiết bị di động.
-*   Sync Manager: Đồng bộ hóa thông minh khi có mạng (Background Sync).
+**Lý do:** Sprint 7 (Knowledge Base) RAG pipeline sẽ trống rỗng nếu không chuẩn bị tài liệu trước. Thu thập + review + annotation mất 3–4 tuần.
 
-### Sprint 6: Agronomy Engine V1
-*   Thuật toán tưới tiêu, bón phân.
-*   Lập lịch canh tác dựa trên giống cây (Robusta/Arabica).
+### 3.2 Pháp lý — Song song với Sprint 2
 
-### Sprint 7: Knowledge Base & Vector Indexing
-*   RAG Pipeline: PDF Parsing, Chunking & Embedding.
-*   Lưu trữ Vector vào Qdrant (Hybrid Search).
+```
+Luật sư chuyên Nghị định 13/2023/NĐ-CP review:
+  - Data Privacy Policy (docs/legal/privacy-policy-dpa-dsr.md)
+  - Personal Data Processing Agreement (DPA)
+  - Terms of Service
 
-### Sprint 8: AI Orchestrator (Semantic Kernel)
-*   Định nghĩa Plugins cho Agronomy, Weather, Market.
-*   Cơ chế Intent Classification (Phân loại ý định).
+Phải hoàn thành trước khi onboard farmer thật trong Sprint 12.
+```
 
-### Sprint 9: Real-time Agentic Chat
-*   SignalR Hub cho streaming phản hồi AI.
-*   Cơ chế phản hồi người dùng (Up/Down vote) cho RLHF.
+### 3.3 Golden Test Set — Chuẩn bị trước Sprint 7
 
-### Sprint 10: Market & Price Monitoring
-*   Sync giá cà phê ICE Futures & Đại lý địa phương.
-*   Công cụ tính ROI & Tìm kiếm người mua (Geo-query).
+```
+WASI agronomist tạo 200 cặp (câu hỏi + expected answer):
+  - 50 disease diagnosis cases
+  - 40 fertilizer advice cases
+  - 30 irrigation cases
+  - 30 cross-lingual (VI query → EN doc)
+  - 25 technical term queries
+  - 25 market/ROI questions
 
-### Sprint 11: Proactive Alerts & Scheduler
-*   Hangfire Jobs cho báo cáo tuần.
-*   Cảnh báo dịch bệnh vùng dựa trên dữ liệu tổng hợp.
-
-### Sprint 12: Enterprise Observability & Pilot
-*   Giám sát SLA, Seq, Grafana.
-*   Diễn tập khôi phục sau sự cố (Disaster Recovery).
-*   **Pilot Launch:** Triển khai thử nghiệm 50 hộ nông dân.
+Dùng để: Đo Recall@5 (target ≥ 0.80) trước khi claim AI production-ready.
+```
 
 ---
 
-## 4. Các Trụ cột Enterprise (Enterprise Pillars)
+## 4. Sprint Plan Chi tiết (13 Sprints)
 
-### 4.1 Data Validation Layer
-Mọi dữ liệu từ sensor/người dùng phải đi qua lớp kiểm chứng (Schema validation, Range check, Logic check) trước khi được AI sử dụng để tránh "Garbage In, Garbage Out".
+### ✅ Sprint 1 — Infrastructure & Shared Kernel
+**Status: COMPLETED**
+**Phase:** 1
 
-### 4.2 Privacy by Design
-Dữ liệu vườn của nông dân là tài sản riêng. Hệ thống mặc định không chia sẻ dữ liệu chi tiết nếu không có sự đồng ý tường minh.
+```
+Đã hoàn thành:
+  ✅ CI/CD Pipelines (GitHub Actions)
+  ✅ Shared Kernel (.NET 8 / Python 3.12)
+  ✅ API Gateway (YARP) — basic routing
+  ✅ Docker Compose stack — tất cả services healthy
+  ✅ MongoDB Replica Set (3 nodes) — khởi tạo thành công
+  ✅ RabbitMQ + Qdrant + Redis baseline
+  ✅ Seq + Prometheus + Grafana baseline
+```
 
-### 4.3 Resilience & Offline-first
-Hệ thống phải chịu được sự gián đoạn kết nối tại Tây Nguyên bằng cách xử lý ngầm (Asynchronous) và đồng bộ trễ.
+**Lưu ý cho Sprint tiếp theo:**
+- Verify MongoDB keyFile đã generate đúng (`make gen-keyfile`)
+- Confirm tất cả `.env` secrets đã được set trên staging server
+- Branch protection rules đã bật trên `main` và `develop` chưa?
 
 ---
 
-## 5. Chỉ số Đo lường (KPIs)
-*   **Latency:** < 2s cho luồng AI SignalR.
-*   **Reliability:** 99.9% cho các dịch vụ Identity & IoT Ingestion.
-*   **Accuracy:** > 90% độ chính xác cho các cảnh báo bệnh/tưới tiêu.
-*   **User Retention:** > 60% nông dân quay lại sử dụng sau tuần đầu tiên.
+### Sprint 2 — Identity, Privacy & Data Sovereignty
+**Phase:** 1 | **Phụ thuộc:** Sprint 1 ✅
+
+**Sprint Goal:** Nông dân đăng ký và đăng nhập được. Mọi PII được bảo vệ đúng quy định.
+
+```
+Deliverables:
+  □ OTP authentication — Zalo + SMS fallback
+  □ JWT RS256 (asymmetric) — không dùng HS256
+  □ Refresh token rotation — hashed in MongoDB
+  □ PII Encryption (AES-256) cho phoneNumber, fullName, GPS
+  □ Consent Management — farmer đồng ý trước khi lưu data
+  □ Rate limiting OTP: 5 attempts / 15 phút / số điện thoại
+  □ Farmer profile + Farm CRUD
+  □ UserContext document (MongoDB) — seed data cho AI context
+```
+
+**Definition of Done:**
+- JWT forge attempt → 401 (RS256 verified)
+- PII fields encrypted in MongoDB Atlas view
+- Privacy Policy text hiển thị và farmer must accept trước khi register
 
 ---
+
+### Sprint 3a — Resilient Messaging (RabbitMQ Core)
+**Phase:** 1 | **Phụ thuộc:** Sprint 2
+
+**Sprint Goal:** Mọi domain event được gửi reliable, không mất message khi service restart.
+
+> **Lý do tách Sprint 3:** Outbox Pattern + RabbitMQ setup là một sprint đầy. Gộp với Zalo integration sẽ thiếu thời gian test kịch bản mạng chập chờn — loại bug gây mất notification quan trọng.
+
+```
+Deliverables:
+  □ Outbox Pattern implementation (MongoDB-backed)
+  □ RabbitMQ Exchanges & Queues theo definitions.json
+  □ MassTransit consumer base class với retry + DLQ
+  □ Dead Letter Queue monitoring alert
+  □ Idempotency store (Redis SET NX) cho consumers
+  □ Event contracts đầy đủ (xem RabbitMQ Event Catalog)
+
+Events cần có trong sprint này:
+  - FarmerRegisteredEvent
+  - FarmerLocationUpdatedEvent
+  - FarmAddedEvent
+```
+
+---
+
+### Sprint 3b — Notification Service & Zalo Integration
+**Phase:** 1 | **Phụ thuộc:** Sprint 3a
+
+**Sprint Goal:** Nông dân nhận được notification qua Zalo khi có cảnh báo quan trọng.
+
+```
+Deliverables:
+  □ Zalo OA API integration
+  □ FCM (Firebase Cloud Messaging) cho mobile push
+  □ SMS fallback (Twilio)
+  □ Notification Template Engine (disease alert, price alert, weather)
+  □ Zalo Token refresh job (Hangfire, mỗi 80 ngày)
+  □ Zalo Bot webhook — nhận câu hỏi qua Zalo
+
+Test scenarios bắt buộc:
+  - Mạng chập chờn: message retry đúng không?
+  - Token expired: auto refresh không?
+  - Zalo down: FCM fallback kịp thời không?
+```
+
+---
+
+### Sprint 4 — IoT Ingestion & Data Quality Assurance
+**Phase:** 2 | **Phụ thuộc:** Sprint 3a
+
+**Sprint Goal:** Dữ liệu sensor được ingest đáng tin cậy, dữ liệu nhiễu bị loại bỏ trước khi vào AI.
+
+```
+Deliverables:
+  □ MQTT Broker — port 1883 (plain) + 8883 (TLS)
+  □ Sensor Topic Router: bazan/{farmId}/{sensorType}/{deviceId}
+  □ HMAC device authentication
+  □ Data Validation Layer:
+      - Schema validation (đúng field, đúng type)
+      - Range check (soil moisture 0–100%, pH 3.0–9.0, v.v.)
+      - Logic check (so sánh với lần đo trước — outlier detection)
+  □ Multi-sensor payload support (gateway device)
+  □ DLQ cho sensor data lỗi (không block queue chính)
+  □ IoT queue bounded: max 100,000 messages, drop-head policy
+  □ Threshold alerts → publish lên RabbitMQ:
+      soil_moisture < 30% → IrrigationReminderCreated
+      pH < 5.5 hoặc > 7.0 → SoilPhAlertCreated
+
+Sensor TTL: 90 ngày (TTL index trong MongoDB)
+```
+
+**KPI sprint:** Sensor data accuracy > 95% (đo bằng so sánh với ground truth sample).
+
+---
+
+### Sprint 5 — Offline-first Architecture
+**Phase:** 2 | **Phụ thuộc:** Sprint 3b, Sprint 4
+
+**Sprint Goal:** App hoạt động đủ tốt kể cả ở vùng không có sóng (30% vườn Tây Nguyên).
+
+```
+Deliverables (Flutter):
+  □ Drift (SQLite) local storage — type-safe, compile-time checked
+  □ 3-tier data cache:
+      Tier 1 (luôn offline): lịch canh tác 30 ngày, 20 sessions gần nhất, cảnh báo chưa đọc
+      Tier 2 (sync khi mở app): history cũ hơn
+      Tier 3 (chỉ online): AI chat real-time, ảnh HD
+  □ Outbox pattern (client): queue messages khi offline → flush khi có mạng
+  □ Background Sync Worker (mỗi 15 phút khi có mạng)
+  □ Conflict resolution: Server wins (AI content), Client wins (observations)
+  □ Offline indicator UX — banner amber "Đang xem dữ liệu đã lưu"
+  □ Delta sync API endpoint — chỉ pull changes từ lastSync
+
+Test bắt buộc:
+  - Airplane mode → ghi chép → restore network → data sync đúng không?
+  - Mạng chập chờn (throttle 50kbps) → app không crash
+```
+
+---
+
+### Sprint 6 — Knowledge Base & Vector Indexing
+**Phase:** 3 | **Phụ thuộc:** Sprint 1 ✅, WASI Prep (xem Mục 3.1)
+
+> **Lý do đổi vị trí (từ Sprint 7 → Sprint 6):** Knowledge Base là foundation của AI Orchestrator. Nếu làm Agronomy Engine trước, engine sẽ hard-code rules → phải refactor khi tích hợp RAG. Làm Knowledge Base trước = Agronomy Engine có thể dùng RAG context ngay từ đầu.
+
+**Sprint Goal:** RAG Pipeline hoạt động, Recall@5 ≥ 0.80 trên Golden Test Set.
+
+```
+Deliverables:
+  □ PDF ingestion pipeline (MinIO → parse → chunk → embed → Qdrant)
+  □ Chunking: 512 tokens, 64 overlap, RecursiveCharacterTextSplitter
+  □ Embedding: text-embedding-3-large (OpenAI), 3072 dims
+  □ Qdrant collections:
+      - wcr_documents (3072d, INT8 quantization)
+      - agronomy_knowledge (3072d)
+      - pest_disease_library (3072d)
+      - market_reports (1536d — Matryoshka)
+  □ Hybrid Search: Dense (text-embedding-3-large) + Sparse (BM42) + RRF fusion
+  □ Payload indexes: coffee_varieties, topics, region, growth_stages, language
+  □ Metadata annotation schema + validation
+  □ Query embedding cache (Redis, TTL 1h)
+  □ Vietnamese preprocessor:
+      - Diacritic restoration (vncorenlp)
+      - Regional term normalization ("mọt đục cành" → "Hypothenemus hampei")
+      - Technical term protection (NPK 16-16-8, TR4, pH 6.2)
+  □ Banned chemicals hardcode list (không phụ thuộc LLM)
+
+Initial content (cần chuẩn bị xong từ WASI Prep):
+  - 30 tài liệu WASI kỹ thuật canh tác
+  - 20 tài liệu WCR (Open Access)
+  - Danh mục thuốc BVTV 2024
+```
+
+**Gate:** Recall@5 ≥ 0.80 trên 200-case Golden Test Set TRƯỚC KHI proceed Sprint 7.
+
+---
+
+### Sprint 6b — Computer Vision Disease Detection
+**Phase:** 3 | **Chạy song song với Sprint 6 hoặc ngay sau**
+
+> **Lý do thêm sprint này:** PRD và User Story Map đều có tính năng chụp ảnh chẩn đoán bệnh — là tính năng nông dân muốn nhất. Không có trong roadmap gốc là gap quan trọng.
+
+**Sprint Goal:** Nông dân chụp ảnh lá bệnh → AI chẩn đoán được bệnh với confidence score.
+
+```
+Deliverables:
+  □ Azure Custom Vision setup (Phase 1 — không cần GPU)
+  □ Image upload flow: Camera/Gallery → MinIO (pre-signed URL) → CV API
+  □ 10 disease classes Phase 1:
+      leaf_rust, anthracnose, phoma_blight, root_rot, berry_borer,
+      mealybug, stem_borer, nutrient_deficiency_mg, nutrient_deficiency_n, healthy
+  □ Confidence score display trong app
+  □ Low confidence (< 0.60) → request more photos / clarification
+  □ WASI image labeling workflow (CVAT tool)
+  □ Training dataset: ≥ 300 ảnh/class (phối hợp WASI)
+  □ CV result integration vào Agronomy Diagnosis flow
+
+Targets:
+  - Overall accuracy ≥ 80% (Phase 1)
+  - Inference latency < 2s (Azure Custom Vision API)
+```
+
+---
+
+### Sprint 7 — Agronomy Engine V1
+**Phase:** 3 | **Phụ thuộc:** Sprint 6 (Knowledge Base ready, Recall@5 ≥ 0.80)
+
+> **Lý do đổi vị trí (từ Sprint 6 → Sprint 7):** Agronomy Engine giờ có thể tận dụng RAG context ngay từ V1, thay vì hard-code rules rồi refactor.
+
+**Sprint Goal:** Nông dân nhận được lịch canh tác cá nhân hóa và chẩn đoán bệnh có nguồn tham khảo.
+
+```
+Deliverables:
+  □ Disease diagnosis endpoint — kết hợp:
+      + CV result (Sprint 6b)
+      + RAG knowledge retrieval (Sprint 6)
+      + Farmer context (giống, đất, vùng)
+  □ Irrigation plan algorithm (dựa trên sensor + weather + schedule)
+  □ Fertilizer recommendation — cá nhân hóa theo:
+      giống cây (Robusta/Arabica/TR4), giai đoạn sinh trưởng, kết quả phân tích đất
+  □ 30-day cultivation schedule generator
+  □ Soil analysis input + amendment recommendations
+  □ Pest alert aggregation theo GPS vùng
+  □ Seasonal calendar (12 tháng Tây Nguyên)
+
+Domain rules (từ WASI, không hard-code):
+  - 6 yếu tố canh tác: Đất, Nước, Giống, Phân bón, Sâu bệnh, Thu hoạch
+  - Mọi recommendation phải có sourceDocument (WCR/WASI docId)
+  - Mọi thuốc phải kiểm tra banned chemicals list trước khi recommend
+```
+
+---
+
+### Sprint 8 — AI Orchestrator (Semantic Kernel)
+**Phase:** 3 | **Phụ thuộc:** Sprint 6 (RAG), Sprint 7 (Agronomy), Sprint 3b (Notifications)
+
+**Sprint Goal:** AI Agent tự lập kế hoạch gọi đúng tools, trả lời câu hỏi phức hợp (bệnh + thời tiết + giá) trong một response.
+
+```
+Deliverables:
+  □ Semantic Kernel 1.x setup với GPT-4o (RS256)
+  □ Plugin system:
+      - AgronomyPlugin   → Agronomy Service (port 5004)
+      - KnowledgePlugin  → RAG Service (port 5003)
+      - WeatherPlugin    → Weather Service (port 5008)
+      - MarketPlugin     → Market Service (port 5005) [stub, đầy đủ Sprint 10]
+      - FarmerContextPlugin → Identity Service (port 5001)
+  □ AutoFunctionCalling — AI tự quyết định gọi tool nào
+  □ Intent Classifier (GPT-4o-mini) — 12 intent classes, confidence > 0.6
+  □ Token budget management:
+      system: 1200 + context: 300 + history: 2000 + RAG: 2000 + query: 200 = max 5700
+  □ Sliding window conversation history (giữ first 3 + last N + summary marker)
+  □ Prompt Engineering v1.0 — theo Prompt Playbook
+  □ Prompt Registry: src/.../Prompts/v1/
+  □ Diacritic restoration cho query expansion
+
+Circuit breakers (Polly):
+  - OpenAI API: retry 3x, exponential backoff, circuit breaker
+  - Agronomy Service: timeout 5s
+  - RAG Service: timeout 500ms
+```
+
+---
+
+### Sprint 9 — Real-time Agentic Chat
+**Phase:** 3 | **Phụ thuộc:** Sprint 8 (Orchestrator)
+
+**Sprint Goal:** Nông dân nhận câu trả lời AI streaming từng token, P95 < 3 giây.
+
+```
+Deliverables:
+  □ SignalR Hub: wss://api.bazanai.vn/hub/chat
+  □ Streaming flow:
+      SendMessage → TypingIndicator stages → ReceiveToken (per token) → StreamComplete
+  □ Client events: SendMessage, CancelStream, SubmitFeedback, Ping
+  □ Server events: ReceiveToken, StreamComplete, StreamError, TypingIndicator, Pong
+  □ Auto-reconnect (exponential backoff: 0ms, 2s, 10s, 30s)
+  □ Offline message queue (client-side outbox)
+  □ RLHF feedback: 👍/👎 per message + star rating per session
+  □ RLHF export pipeline:
+      Daily job → anonymize PII → DPO format → MinIO bazan-backups/rlhf/
+  □ StreamError handling với error codes: llm_timeout, rate_limit, invalid_session
+  □ Citations display (sourceTitle, pageStart, pageEnd)
+
+Performance targets:
+  - TTFT (Time to First Token): < 500ms P50, < 2s P95
+  - Full response: < 1.5s P50, < 3s P95
+  - SignalR idle timeout: 5 phút
+  - Ping interval: 25s (avoid load balancer timeout)
+```
+
+---
+
+### Sprint 10 — Market & Price Monitoring
+**Phase:** 4 | **Phụ thuộc:** Sprint 8 (MarketPlugin stub)
+
+**Sprint Goal:** Nông dân biết giá cà phê hôm nay, nhận cảnh báo khi giá biến động > 5%.
+
+```
+Deliverables:
+  □ ICE Futures API integration (Robusta London, cập nhật mỗi 3h)
+  □ Redis cache giá (TTL 5 phút) — không gọi ICE API mỗi request
+  □ Đại lý thu mua — geo-query MongoDB 2dsphere (tìm đại lý gần GPS vườn)
+  □ ROI Calculator:
+      revenue = yield_kg × selling_price
+      netProfit = revenue - totalCosts
+      roi_pct = netProfit / totalCosts × 100
+      breakevenPrice = totalCosts / yield_kg
+  □ Sell vs Hold analysis
+  □ Price forecast (30 ngày, với disclaimer)
+  □ Price alert: CoffeePriceUpdated event khi change > 5%
+  □ Zalo/FCM notification khi alert triggered
+  □ Price history chart (7/30/90 ngày)
+
+API phụ thuộc:
+  - ICE Futures: $200/tháng — confirm subscription trước sprint
+  - OpenWeatherMap Pro: $40/tháng
+```
+
+---
+
+### Sprint 11 — Proactive Alerts, Scheduler & Security Audit
+**Phase:** 4 | **Phụ thuộc:** Sprint 10
+
+**Sprint Goal:** Hệ thống chủ động cảnh báo nông dân. Bảo mật đã được audit trước pilot.
+
+```
+Deliverables — Alerts & Scheduler:
+  □ Hangfire Jobs:
+      - Daily RLHF export (2AM)
+      - Weekly market summary (Thứ 2 7AM)
+      - Disease alert aggregation (mỗi 6h)
+      - Zalo token refresh (mỗi 80 ngày)
+      - MongoDB backup (3AM daily → MinIO)
+  □ Disease alert theo GPS vùng
+      (tổng hợp: nếu > N farms trong bán kính R bị bệnh X → broadcast alert)
+  □ Weather alert: dry_spell, heavy_rain, heat_stress, frost_risk
+  □ Irrigation reminder từ sensor threshold (soil_moisture < 30%)
+  □ Harvest window notification (maturityScore > 0.80)
+
+Deliverables — Security Audit:
+  □ OWASP ZAP automated scan trên staging
+  □ Manual auth testing:
+      - JWT RS256 forge attempt → 403
+      - BOLA: Farmer A token → GET /farmers/{farmer_B_id} → 403
+      - OTP brute force: bị block sau attempt thứ 6
+      - Rate limit: 429 sau 61 requests/phút
+  □ Trivy full scan — zero CRITICAL vulns trước pilot
+  □ Penetration test nhẹ (internal hoặc external vendor)
+  □ Fix mọi finding trước Sprint 12
+
+Lý do audit ở Sprint 11 (không phải sau): Phải clean security trước khi mời
+farmer thật vào Sprint 12. Không thể rollback sau khi có real user data.
+```
+
+---
+
+### Sprint 12 — Enterprise Observability & Pilot Launch
+**Phase:** 4 | **Phụ thuộc:** Sprint 11 (Security audit passed)
+
+> **Lưu ý quan trọng:** Observability phải **stable và đã test** trước khi mời farmer thật. Sprint này chia thành 2 tuần rõ ràng: Tuần 1 = Observability hardening, Tuần 2 = Pilot launch.
+
+**Sprint Goal:** 50 nông dân pilot sử dụng app thực tế. Team có đầy đủ visibility để detect và fix issues ngay.
+
+```
+Tuần 1 — Observability Hardening:
+  □ Grafana dashboards đầy đủ:
+      - System Overview (API rate, error rate, P95 latency)
+      - AI Quality (thumbs-up rate, re-ask rate, safety violations)
+      - Database Performance (MongoDB, Qdrant, Redis)
+      - Business Metrics (DAU, sessions, feedback)
+  □ Alert rules: ServiceDown (Critical), APIErrorRateHigh (Critical),
+    FeedbackRateDrop (Warning), OpenAICostSpike (Warning)
+  □ PagerDuty routing: Critical → on-call phone + Slack
+  □ Disaster Recovery drill:
+      - Kill MongoDB Primary → verify failover < 30s
+      - Restore từ backup vào DR environment
+  □ Smoke test suite (15 critical paths) tự động sau mỗi deploy
+  □ Runbook hoàn chỉnh cho mọi Critical alert
+
+Tuần 2 — Pilot Launch (50 nông dân):
+  □ Onboard 50 nông dân qua 2 HTX (Cư M'gar + Ea H'leo)
+  □ 1-on-1 setup session 15 phút/nông dân cho người ít quen tech
+  □ Zalo group support riêng cho pilot group
+  □ Daily check: Grafana AI quality dashboard
+  □ Weekly WASI expert review: 20 sample responses
+  □ NPS survey sau 2 tuần pilot
+```
+
+**Definition of Done cho roadmap Phase 1:**
+- D7 retention ≥ 50%
+- Thumbs-up rate ≥ 70%
+- Zero Critical security incidents
+- Expert accuracy ≥ 4.0/5.0 (WASI review)
+- P95 response latency < 3s
+
+---
+
+## 5. Dependency Map
+
+```
+Sprint 1 ✅
+    │
+    ├──► Sprint 2 (Identity)
+    │         │
+    │         ├──► Sprint 3a (RabbitMQ)
+    │         │         │
+    │         │         ├──► Sprint 4 (IoT)
+    │         │         │         │
+    │         │         │         └──► Sprint 5 (Offline)
+    │         │         │
+    │         │         └──► Sprint 3b (Zalo)
+    │         │                    │
+    │         │                    └──► Sprint 10 (Market)
+    │         │                                │
+    │         │                                └──► Sprint 11 (Alerts + Audit)
+    │         │                                              │
+    │         │                                              └──► Sprint 12 (Pilot)
+    │         │
+    └─────────┤
+              │
+   [WASI Prep]──► Sprint 6 (RAG/KB) ──► [Gate: Recall@5 ≥ 0.80]
+                        │
+              Sprint 6b (CV) ──► Sprint 7 (Agronomy Engine)
+                        │                │
+                        └────────────────┼──► Sprint 8 (Orchestrator)
+                                                   │
+                                              Sprint 9 (Chat)
+```
+
+---
+
+## 6. Các Trụ cột Enterprise
+
+### 6.1 Data Validation Layer (Anti-GIGO)
+
+Mọi dữ liệu từ sensor/người dùng phải đi qua 3 lớp kiểm chứng trước khi AI xử lý:
+
+| Lớp | Kiểm tra | Ví dụ |
+|-----|---------|-------|
+| Schema validation | Đúng field, đúng type | `soilMoisture_pct` phải là number |
+| Range check | Trong ngưỡng vật lý hợp lệ | moisture 0–100%, pH 3.0–9.0 |
+| Logic check | Nhất quán với context | Độ ẩm tăng 50% trong 1 phút → outlier |
+
+Dữ liệu fail validation → DLQ (không silently drop, không block queue).
+
+### 6.2 Privacy by Design
+
+- GPS vườn round đến 0.01° (~1km) trước khi lưu
+- Phone number, fullName mã hóa AES-256 trong MongoDB
+- Consent bắt buộc trước khi thu thập mỗi loại data
+- Farmer có thể yêu cầu export toàn bộ data hoặc xóa tài khoản bất kỳ lúc nào
+- OpenAI: PII stripping trước khi gửi prompt, Zero Data Retention option bật
+
+### 6.3 Resilience & Offline-first
+
+- Docker restart policy: `unless-stopped` cho tất cả services
+- RabbitMQ Outbox Pattern — message không mất khi service restart
+- Offline cache 3 tiers — core features hoạt động không cần mạng
+- MongoDB Replica Set 3 nodes — failover tự động < 30 giây
+- Circuit breakers (Polly) cho tất cả external API calls
+
+### 6.4 AI Safety (Non-negotiable)
+
+- Banned chemicals list hardcoded — không phụ thuộc LLM
+- Mọi recommendation thuốc phải có citation từ Bộ NN&PTNT
+- Confidence score bắt buộc cho disease diagnosis
+- Safety incident alert → PagerDuty ngay lập tức (zero tolerance)
+- WASI expert review mỗi tuần trong giai đoạn pilot
+
+### 6.5 Observability-first
+
+Không deploy feature mới nếu không có:
+- Grafana panel theo dõi metric liên quan
+- Alert rule cho threshold vi phạm
+- Log query mẫu trong Runbook
+
+---
+
+## 7. KPIs Tổng hợp
+
+### 7.1 Business KPIs
+
+| Metric | Phase 1 (T3) | Phase 2 (T6) | Phase 3 (T9) | Phase 4 (T12) |
+|--------|-------------|-------------|-------------|--------------|
+| Registered farmers | 100 | 500 | 2,000 | 5,000 |
+| DAU | 60 | 300 | 1,200 | 3,000 |
+| D7 retention | ≥ 50% | ≥ 52% | ≥ 55% | ≥ 55% |
+| D30 retention | ≥ 40% | ≥ 42% | ≥ 45% | ≥ 45% |
+| NPS | ≥ 40 | ≥ 45 | ≥ 50 | ≥ 55 |
+| HTX partners | 3 | 10 | 20 | 50 |
+| MRR | $0 | $850 | $3,700 | $10,000 |
+
+### 7.2 Technical KPIs
+
+| Metric | Target | Đo bằng |
+|--------|--------|---------|
+| AI response P95 | < 3s | Grafana |
+| API availability | ≥ 99.5% | Synthetic ping |
+| RAG Recall@5 | ≥ 0.85 | Weekly eval |
+| Thumbs-up rate | ≥ 75% | In-app feedback |
+| Expert accuracy | ≥ 4.0/5.0 | WASI weekly review |
+| Hallucination rate | < 1% | Safety monitor |
+| Sensor data accuracy | > 95% | Ground truth sample |
+| MongoDB failover | < 30s | Monthly DR drill |
+| Price data latency | < 5 phút | Metrics |
+| CV disease accuracy | ≥ 80% | Golden image set |
+
+---
+
+## 8. Risk Register
+
+| # | Rủi ro | Likelihood | Impact | Mitigation |
+|---|--------|-----------|--------|-----------|
+| R1 | WASI chưa sẵn sàng cung cấp tài liệu | Trung bình | Rất cao | Bắt đầu liên hệ ngay tuần này. Fallback: WCR Open Access (200 docs) |
+| R2 | OpenAI API outage | Thấp | Cao | Circuit breaker + retry. Phase 4: local LLM fallback |
+| R3 | Nông dân không tải app (prefer Zalo) | Cao | Cao | Zalo Bot là entry point, upsell sang app sau |
+| R4 | Mạng 3G không đủ để stream AI | Cao | Trung bình | Offline cache + aggressive response compression |
+| R5 | PDPA violation trước khi có Privacy Policy | Thấp | Rất cao | Luật sư review TRƯỚC khi onboard farmer thật |
+| R6 | OpenAI cost spike khi scale | Trung bình | Trung bình | Cache, gpt-4o-mini cho intent, cost alert |
+| R7 | CV model accuracy thấp | Trung bình | Trung bình | Azure Custom Vision Phase 1, tăng training data |
+| R8 | Security vulnerability phát hiện sau pilot | Thấp | Cao | Security audit bắt buộc Sprint 11 trước Sprint 12 |
+
+---
+
+## 9. Thay đổi so với v1.1.0
+
+| Thay đổi | Lý do |
+|---------|-------|
+| Sprint 6↔7 hoán đổi | Knowledge Base là dependency của Agronomy Engine. Làm đúng thứ tự tránh refactor |
+| Sprint 3 tách thành 3a + 3b | RabbitMQ và Zalo integration đủ lớn để là 2 sprints riêng |
+| Thêm Sprint 6b (CV Detection) | Feature quan trọng trong PRD nhưng thiếu trong roadmap gốc |
+| Security Audit vào Sprint 11 | Phải xong trước pilot (Sprint 12), không thể làm sau |
+| Thêm Mục 3 (Hoạt động Chuẩn bị) | WASI partnership và pháp lý cần bắt đầu ngay, không chờ đến sprint liên quan |
+| Cập nhật KPI table | Align với PRD và KPI Dashboard document |
+| Thêm Dependency Map | Visualize dependencies để tránh bắt đầu sprint khi chưa đủ điều kiện |
+| Sprint 12 tách thành 2 tuần rõ ràng | Observability phải stable trước khi mời farmer thật |
+
+---
+
+*Roadmap được review mỗi Sprint Retrospective. Mọi thay đổi phải được Engineering Lead + Product Lead approve.*
+
 **© 2026 Bazan AI — Confidential Business Document**

--- a/BazanAI/infra/.env.example
+++ b/BazanAI/infra/.env.example
@@ -28,6 +28,7 @@ ACCEPT_EULA=Y
 JWT_SECRET=bazan_ai_very_long_and_secure_jwt_secret_key_2026
 JWT_EXPIRY_HOURS=24
 PII_ENCRYPTION_KEY=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f # 32-byte hex key
+OTP_PEPPER=bazan_otp_pepper_secret_2026
 
 # External APIs (Placeholders)
 # ==========================================
@@ -38,6 +39,7 @@ OPENAI_MODEL=gpt-4-turbo-preview
 
 # Messaging & Weather
 ZALO_OA_ACCESS_TOKEN=your_zalo_token
+ZALO_OA_OTP_TEMPLATE=your_zalo_template_id
 FCM_SERVER_KEY=your_fcm_key
 OPENWEATHER_API_KEY=your_openweather_key
 

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Commands/SendOtp/SendOtpCommand.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Commands/SendOtp/SendOtpCommand.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BazanAI.Identity.Application.Auth.Common;
+using BazanAI.SharedKernel.Models;
+using FluentValidation;
+using MediatR;
+
+namespace BazanAI.Identity.Application.Auth.Commands.SendOtp;
+
+public record SendOtpCommand(string PhoneNumber) : IRequest<Result<SendOtpResponse>>;
+
+public record SendOtpResponse(DateTime OtpExpiresAt, string Message = "OTP đã được gửi");
+
+public class SendOtpCommandValidator : AbstractValidator<SendOtpCommand>
+{
+    public SendOtpCommandValidator()
+    {
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty().WithMessage("Số điện thoại không được để trống")
+            .Matches(@"^\+84[0-9]{9}$").WithMessage("Số điện thoại không hợp lệ (phải bắt đầu bằng +84 và có 9 chữ số tiếp theo)");
+    }
+}
+
+public class SendOtpCommandHandler : IRequestHandler<SendOtpCommand, Result<SendOtpResponse>>
+{
+    private readonly IOtpService _otpService;
+
+    public SendOtpCommandHandler(IOtpService otpService)
+    {
+        _otpService = otpService;
+    }
+
+    public async Task<Result<SendOtpResponse>> Handle(SendOtpCommand request, CancellationToken ct)
+    {
+        var result = await _otpService.SendOtpAsync(request.PhoneNumber, ct);
+        
+        if (!result.IsSuccess)
+            return Result<SendOtpResponse>.Failure(result.ErrorCode, result.Message);
+
+        // Round to seconds to avoid leaking sub-second info
+        var expiresAt = new DateTime(
+            result.Value.Year, result.Value.Month, result.Value.Day, 
+            result.Value.Hour, result.Value.Minute, result.Value.Second, 
+            DateTimeKind.Utc);
+
+        return Result<SendOtpResponse>.Success(new SendOtpResponse(expiresAt));
+    }
+}

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Common/IOtpService.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Common/IOtpService.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BazanAI.SharedKernel.Models;
+
+namespace BazanAI.Identity.Application.Auth.Common;
+
+/// <summary>
+/// Service for generating, storing, and sending OTP for authentication.
+/// </summary>
+public interface IOtpService
+{
+    /// <summary>
+    /// Generates a 6-digit OTP, stores its hash in Redis, and sends it to the user.
+    /// </summary>
+    /// <param name="phoneNumber">User's phone number in format +84...</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Expiry time of the generated OTP</returns>
+    Task<Result<DateTime>> SendOtpAsync(string phoneNumber, CancellationToken ct = default);
+
+    /// <summary>
+    /// Verifies the provided OTP against the stored hash in Redis.
+    /// </summary>
+    /// <param name="phoneNumber">User's phone number</param>
+    /// <param name="otp">Plaintext 6-digit OTP</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>True if OTP is valid and matches</returns>
+    Task<Result<bool>> VerifyOtpAsync(string phoneNumber, string otp, CancellationToken ct = default);
+}

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Common/IZaloClient.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Application/Auth/Common/IZaloClient.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BazanAI.SharedKernel.Models;
+
+namespace BazanAI.Identity.Application.Auth.Common;
+
+public interface IZaloClient
+{
+    Task<Result<bool>> SendOtpAsync(string phoneNumber, string otp, CancellationToken ct = default);
+}

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/DependencyInjection.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,8 @@
+using BazanAI.Identity.Application.Auth.Common;
 using BazanAI.Identity.Domain.Repositories;
+using BazanAI.Identity.Infrastructure.ExternalServices;
 using BazanAI.Identity.Infrastructure.Persistence;
+using BazanAI.Identity.Infrastructure.Security;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +13,10 @@ public static class DependencyInjection
     public static IServiceCollection AddIdentityInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IFarmerRepository, FarmerRepository>();
-        // Infrastructure-specific registrations
+        
+        services.AddScoped<IOtpService, OtpService>();
+        services.AddHttpClient<IZaloClient, ZaloClient>();
+
         return services;
     }
 }

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/ExternalServices/ZaloClient.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/ExternalServices/ZaloClient.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BazanAI.Identity.Application.Auth.Common;
+using BazanAI.SharedKernel.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BazanAI.Identity.Infrastructure.ExternalServices;
+
+public class ZaloClient : IZaloClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _accessToken;
+    private readonly string _templateId;
+    private readonly ILogger<ZaloClient> _logger;
+
+    public ZaloClient(HttpClient httpClient, IConfiguration configuration, ILogger<ZaloClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _accessToken = configuration["ZALO_OA_ACCESS_TOKEN"] ?? throw new InvalidOperationException("ZALO_OA_ACCESS_TOKEN is not configured.");
+        _templateId = configuration["ZALO_OA_OTP_TEMPLATE"] ?? throw new InvalidOperationException("ZALO_OA_OTP_TEMPLATE is not configured.");
+        
+        _httpClient.BaseAddress = new Uri("https://openapi.zalo.me/");
+    }
+
+    public async Task<Result<bool>> SendOtpAsync(string phoneNumber, string otp, CancellationToken ct = default)
+    {
+        try
+        {
+            var requestBody = new
+            {
+                recipient = new { user_id = phoneNumber }, // Note: Real ZNS uses user_id or phone
+                message = new
+                {
+                    attachment = new
+                    {
+                        type = "template",
+                        payload = new
+                        {
+                            template_type = "zns",
+                            template_id = _templateId,
+                            template_data = new { otp = otp }
+                        }
+                    }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(requestBody);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            _httpClient.DefaultRequestHeaders.Clear();
+            _httpClient.DefaultRequestHeaders.Add("access_token", _accessToken);
+
+            // POST v3.0/oa/message/cs
+            var response = await _httpClient.PostAsync("v3.0/oa/message/cs", content, ct);
+            
+            if (response.IsSuccessStatusCode)
+            {
+                return Result<bool>.Success(true);
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync(ct);
+            _logger.LogError("Zalo API error: {StatusCode} - {Error}", response.StatusCode, errorContent);
+            return Result<bool>.Failure("zalo_api_error", $"Zalo API returned {response.StatusCode}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send Zalo message to {PhoneNumber}", phoneNumber);
+            return Result<bool>.Failure("zalo_exception", "Internal error calling Zalo API");
+        }
+    }
+}

--- a/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/Security/OtpService.cs
+++ b/BazanAI/src/Services/BazanAI.Identity/BazanAI.Identity.Infrastructure/Security/OtpService.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BazanAI.Identity.Application.Auth.Common;
+using BazanAI.SharedKernel.Models;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BazanAI.Identity.Infrastructure.Security;
+
+public class OtpService : IOtpService
+{
+    private readonly IDistributedCache _cache;
+    private readonly IZaloClient _zaloClient;
+    private readonly string _pepper;
+    private readonly ILogger<OtpService> _logger;
+    private const int OtpExpiryMinutes = 5;
+
+    public OtpService(
+        IDistributedCache cache, 
+        IZaloClient zaloClient,
+        IConfiguration configuration, 
+        ILogger<OtpService> logger)
+    {
+        _cache = cache;
+        _zaloClient = zaloClient;
+        _logger = logger;
+        _pepper = configuration["OTP_PEPPER"] ?? throw new InvalidOperationException("OTP_PEPPER is not configured.");
+    }
+
+    public async Task<Result<DateTime>> SendOtpAsync(string phoneNumber, CancellationToken ct = default)
+    {
+        try
+        {
+            // 1. Generate 6-digit OTP
+            var otp = RandomNumberGenerator.GetInt32(100000, 999999).ToString();
+
+            // 2. Hash OTP before storing
+            var hashedOtp = HashOtp(otp, phoneNumber);
+
+            // 3. Store in Redis
+            var expiry = DateTime.UtcNow.AddMinutes(OtpExpiryMinutes);
+            var cacheOptions = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(OtpExpiryMinutes)
+            };
+
+            await _cache.SetStringAsync($"otp:{phoneNumber}", hashedOtp, cacheOptions, ct);
+
+            // 4. Send via Zalo
+            var zaloResult = await _zaloClient.SendOtpAsync(phoneNumber, otp, ct);
+            if (!zaloResult.IsSuccess)
+            {
+                _logger.LogWarning("Zalo send failed for {PhoneNumber}, returning failure.", phoneNumber);
+                return Result<DateTime>.Failure(zaloResult.ErrorCode, "Không thể gửi mã OTP qua Zalo.");
+            }
+
+            _logger.LogInformation("OTP sent successfully to {PhoneNumber}", phoneNumber);
+            return Result<DateTime>.Success(expiry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending OTP to {PhoneNumber}", phoneNumber);
+            return Result<DateTime>.Failure("otp_send_failed", "Không thể gửi mã OTP. Vui lòng thử lại sau.");
+        }
+    }
+
+    public async Task<Result<bool>> VerifyOtpAsync(string phoneNumber, string otp, CancellationToken ct = default)
+    {
+        var storedHash = await _cache.GetStringAsync($"otp:{phoneNumber}", ct);
+        if (string.IsNullOrEmpty(storedHash))
+        {
+            return Result<bool>.Failure("otp_expired", "Mã OTP đã hết hạn hoặc không tồn tại.");
+        }
+
+        var currentHash = HashOtp(otp, phoneNumber);
+        if (storedHash != currentHash)
+        {
+            return Result<bool>.Failure("otp_invalid", "Mã OTP không chính xác.");
+        }
+
+        // Delete OTP after successful verification
+        await _cache.RemoveAsync($"otp:{phoneNumber}", ct);
+
+        return Result<bool>.Success(true);
+    }
+
+    private string HashOtp(string otp, string phoneNumber)
+    {
+        // SHA256(otp + phoneNumber + pepper) to prevent global rainbow tables
+        var input = $"{otp}{phoneNumber}{_pepper}";
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hashBytes = SHA256.HashData(bytes);
+        return Convert.ToHexString(hashBytes);
+    }
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,143 +1,1379 @@
-# GEMINI.md - Bazan AI Project Context
+# GEMINI.md — Bazan AI Project Context
 
-This file provides instructional context for Gemini CLI when working on the **Bazan AI** project.
-
-## Project Overview
-**Bazan AI** is an Agentic Microservices platform designed for coffee farmers in Vietnam's Central Highlands. It provides AI-driven insights, market data, and agronomy support using a modern, distributed architecture.
-
-- **Primary Goal:** Empower coffee farmers with real-time AI assistance and data-driven cultivation advice.
-- **Architecture:** Clean Architecture (Domain-Driven Design), Microservices, Agentic AI.
-- **Key Services:**
-    - `Identity`: Farmer registration, authentication (JWT/OTP).
-    - `Conversations`: Chat session management and message history.
-    - `Agronomy`: Disease detection, irrigation planning, soil analysis.
-    - `Market`: Coffee prices, ROI calculations, buyer location.
-    - `Orchestrator`: AI Agent using Semantic Kernel, streaming via SignalR.
-    - `Knowledge RAG`: Python-based Retrieval-Augmented Generation service.
-    - `IoT Ingestion`: Sensor data processing (MQTT).
-    - `Weather`: Meteorological data polling and alerting.
-    - `Gateway`: API Gateway using YARP.
-
-## Tech Stack
-- **Backend:** .NET 8 (C#)
-- **AI Service:** Python 3.12 (FastAPI)
-- **Databases:** MongoDB (Replica Set), Qdrant (Vector DB), Redis (Cache)
-- **Messaging:** RabbitMQ (MassTransit)
-- **AI Orchestration:** Microsoft Semantic Kernel
-- **Observability:** Serilog, Seq, Prometheus, Grafana, OpenTelemetry
-- **Infrastructure:** Docker, Docker Compose
-
-## Building and Running
-The project uses a `Makefile` for common operations:
-
-- **Start Infrastructure:** `make up` (Runs `docker compose -f infra/docker-compose.yml up -d`)
-- **Stop Infrastructure:** `make down`
-- **Build All Images:** `make build`
-- **Initialize Databases:** `make migrate` (Sets up MongoDB replica set)
-- **Run Tests:** `make test` (Runs `dotnet test` and `pytest`)
-- **View Logs:** `make logs`
-
-### Individual Service Development
-- **.NET Services:** `dotnet run --project src/Services/BazanAI.Identity/BazanAI.Identity.API`
-- **Python Service:** `cd src/Python/bazan-knowledge-rag && uvicorn app.main:app --reload`
-
-## Development Conventions
-
-### Naming & Style
-- **C#:** PascalCase for Classes/Methods/Properties, camelCase for variables, `_camelCase` for private fields. Always suffix async methods with `Async`.
-- **Python:** snake_case for functions/variables/modules, PascalCase for classes. Type hints are **mandatory**.
-- **Indentation:** 4 spaces for C# and Python, 2 spaces for JSON/YAML/Markdown (enforced by `.editorconfig`).
-
-### Clean Architecture (C#)
-Strictly follow the dependency flow: `Domain` <- `Application` <- `Infrastructure` / `API`.
-- **Domain:** No external dependencies. Entities, Aggregate Roots, Value Objects, Domain Events.
-- **Application:** CQRS pattern using MediatR. Only depends on Domain.
-- **Infrastructure:** Implementations of repositories and external clients.
-- **API:** Controllers and service registration.
-
-### AI & Data
-- **RAG:** Uses Qdrant for vector storage. Hybrid search (Dense + Sparse/BM42).
-- **Orchestrator:** Uses Semantic Kernel for function calling and intent classification.
-
-### Error Handling
-- Use the `Result<T>` pattern for business logic errors instead of throwing exceptions.
-- Throw exceptions only for infrastructure/unexpected failures.
-
-### Logging
-- Use structured logging with named parameters (Serilog/structlog).
-- Never log PII (Personally Identifiable Information) like phone numbers or exact coordinates without masking.
-
-## Key Files
-- `BazanAI.sln`: Main .NET solution.
-- `infra/docker-compose.yml`: Full infrastructure stack definition.
-- `src/SharedKernel/`: Common logic shared across all .NET microservices.
-- `docs/architecture/`: Detailed design documents (ADRs, Diagrams).
-- `docs/team/coding-standards.md`: Detailed coding standards.
-
-## Project Structure
-```
-BazanAI/
-├── .github/workflows/      # CI/CD Pipelines
-├── docs/                   # Comprehensive documentation
-├── infra/                  # Docker, Configs, DB scripts
-├── src/
-│   ├── Python/             # Python-based AI services
-│   ├── Services/           # .NET Microservices
-│   └── SharedKernel/       # Shared .NET libraries
-├── tests/                  # Unit and Integration tests
-├── Makefile                # Task runner
-└── README.md               # Project overview
-```
-
-## Automated Developer Workflow
-When instructed to "work on issue #X" or "implement feature Y", follow this strict workflow to simulate a Senior Developer's process:
-
-### 1. Preparation & Branching
-1.  **Read Context:** Retrieve issue details using `gh issue view {id}`. Read related `docs/` or existing code to understand the requirement.
-2.  **Sync Main:** Ensure local main is up-to-date: `git checkout main && git pull origin main`.
-3.  **Create Branch:**
-    -   Feature: `git checkout -b feature/{id}-{short-desc}` (e.g., `feature/5-ci-pipeline`)
-    -   Bugfix: `git checkout -b bugfix/{id}-{short-desc}` (e.g., `bugfix/12-login-error`)
-    -   Naming: Lowercase, kebab-case, include ID.
-
-### 2. Implementation & Verification
-1.  **Coding Standards:** Adhere to Clean Architecture, naming conventions, and project style.
-2.  **Testing:**
-    -   **MUST** add or update Unit Tests (`tests/Unit/`) for all new logic.
-    -   Run tests locally: `dotnet test {Project}` or `make test`.
-    -   Ensure build passes: `dotnet build`.
-3.  **Commit Strategy:**
-    -   Use Conventional Commits: `feat(scope): description`, `fix(scope): description`.
-    -   Keep commits granular and logical.
-
-### 3. Pull Request & Review
-1.  **Push:** `git push origin {branch-name}`.
-2.  **Create PR:**
-    -   Command: `gh pr create --base main --head {branch-name} --title "[{TYPE}-{ID}] {Description}" --body "{Template}"`
-    -   Template:
-        ```markdown
-        ## Changes
-        - [Concise list of changes]
-
-        ## Related
-        - Closes #{ID}
-
-        ## Checklist
-        - [x] Unit tests added/updated
-        - [x] Manual testing verified
-        - [x] No PII/Secrets exposed
-        ```
-3.  **Self-Review:**
-    -   Verify diffs.
-    -   Check for "dummy" code or "TODOs".
-    -   Ensure CI checks pass (simulate or check `gh pr checks`).
-
-### 4. Merge & Cleanup
-1.  **Wait for Approval:** Ask user for confirmation to merge if critical.
-2.  **Merge:**
-    -   Command: `gh pr merge {pr-number} --squash --delete-branch`
-    -   Strategy: **Squash Merge** to keep `main` clean.
-3.  **Sync:** `git checkout main && git pull origin main`.
+This file provides permanent project context for Gemini CLI. Read completely before starting any task. Sprint-specific requirements are in `docs/sprints/`.
 
 ---
-*This file is maintained by Gemini CLI to ensure consistent development patterns.*
+
+## 1. Project Overview
+
+**Bazan AI** is an Agentic Microservices platform for coffee farmers in Vietnam's Central Highlands. It delivers AI-driven cultivation advice, market intelligence, and agronomy support.
+
+**North Star Metric:** Weekly Active Value Users (WAVU) — farmers with ≥ 1 quality AI session/week with thumbs-up feedback.
+
+---
+
+## 2. Services & Ports
+
+| Service | Lang | Port | Responsibility |
+|---------|------|------|---------------|
+| `BazanAI.Gateway` | C# | 8080 | YARP API Gateway, JWT validation, rate limiting |
+| `BazanAI.Identity` | C# | 5001 | Auth (OTP/OAuth/Email), Farmer profile, Farm CRUD |
+| `BazanAI.Conversations` | C# | 5002 | Chat sessions, message history, RLHF feedback |
+| `BazanAI.Agronomy` | C# | 5004 | Disease detection, irrigation, cultivation schedule |
+| `BazanAI.Market` | C# | 5005 | Coffee prices, ROI calculator, buyer geo-search |
+| `BazanAI.Notification` | C# | 5006 | Zalo OA, FCM, SMS dispatch |
+| `BazanAI.IoT` | C# | 5007 | MQTT broker, sensor ingestion, DQA |
+| `BazanAI.Weather` | C# | 5008 | Forecast polling, alerts |
+| `BazanAI.Media` | C# | 5009 | MinIO file upload, image pre-processing |
+| `BazanAI.Orchestrator` | C# | 5010 | Semantic Kernel AI agent, SignalR streaming |
+| `BazanAI.Scheduler` | C# | 5011 | Hangfire jobs, RLHF export, backup |
+| `bazan-knowledge-rag` | Python | 5003 | FastAPI RAG service, Qdrant hybrid search |
+
+| Infrastructure | Port | Notes |
+|---------------|------|-------|
+| MongoDB Primary | 27017 | Replica Set `rs0` (3 nodes) |
+| Qdrant HTTP/gRPC | 6333/6334 | Vector DB |
+| Redis | 6379 | Cache, OTP, blacklist |
+| RabbitMQ AMQP | 5672 | Messaging |
+| RabbitMQ UI | 15672 | SSH tunnel only |
+| MinIO API | 9000 | Object storage |
+| Seq | 5341 | Structured logs — SSH tunnel only |
+| Grafana | 3000 | Metrics — SSH tunnel only |
+
+---
+
+## 3. Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | .NET 8 / C# — Clean Architecture, CQRS (MediatR) |
+| Mobile | **React Native** (TypeScript) — NOT Flutter |
+| AI Service | Python 3.12 / FastAPI |
+| Primary DB | MongoDB 7.0 Replica Set |
+| Vector DB | Qdrant 1.9 (hybrid search: dense + BM42 sparse + RRF) |
+| Cache | Redis 7 |
+| Messaging | RabbitMQ 3.13 + MassTransit 8.x |
+| AI Orchestration | Semantic Kernel 1.x + GPT-4o |
+| Embeddings | OpenAI text-embedding-3-large (3072 dims) |
+| Object Storage | MinIO |
+| Observability | Serilog → Seq, Prometheus → Grafana, OpenTelemetry |
+| Infrastructure | Docker Compose (Phase 1–3), Kubernetes (Phase 4) |
+
+---
+
+## 4. Project Structure
+
+```
+BazanAI/
+├── .github/workflows/          # ci.yml, cd-staging.yml, cd-production.yml
+├── docs/
+│   ├── architecture/           # ADR-001..006, DFD, ERD, Sequence Diagrams
+│   ├── api/openapi/            # OpenAPI specs per service
+│   ├── ai/                     # RAG Pipeline, Prompt Playbook, Embedding Strategy
+│   ├── team/                   # Coding Standards, Git Workflow, Testing Strategy
+│   ├── sprints/                # Sprint task specs — READ before implementing
+│   └── postman/                # Postman collections
+├── infra/
+│   ├── docker-compose.yml
+│   ├── .env.example            # Template — NEVER commit .env
+│   ├── mongo-init/             # RS init scripts, keyfile
+│   ├── rabbitmq/               # definitions.json
+│   └── qdrant/config.yaml
+├── src/
+│   ├── Python/bazan-knowledge-rag/
+│   │   ├── app/api/            # FastAPI routers
+│   │   ├── app/domain/         # Services, models
+│   │   ├── app/infrastructure/ # Qdrant, OpenAI clients
+│   │   └── tests/
+│   ├── Services/
+│   │   └── BazanAI.{Service}/
+│   │       ├── BazanAI.{Service}.Domain/
+│   │       ├── BazanAI.{Service}.Application/
+│   │       ├── BazanAI.{Service}.Infrastructure/
+│   │       └── BazanAI.{Service}.API/
+│   └── SharedKernel/
+│       ├── BazanAI.SharedKernel/           # Result<T>, domain primitives
+│       └── BazanAI.Infrastructure.Common/  # MongoDB, Redis, RabbitMQ base
+├── tests/
+│   ├── Unit/
+│   └── Integration/
+├── BazanAI.sln
+└── Makefile
+```
+
+---
+
+## 5. Common Commands
+
+```bash
+# Start / stop full stack
+make up && make health
+make down
+
+# First-time setup only
+make gen-keyfile && make init-rs
+
+# Hot reload a single service
+docker compose stop {service-name}
+cd src/Services/BazanAI.{Service}/BazanAI.{Service}.API
+dotnet watch run --no-launch-profile
+
+# Python RAG service
+cd src/Python/bazan-knowledge-rag && uvicorn app.main:app --reload
+
+# Run all tests
+make test
+
+# Run specific test suite
+dotnet test tests/Unit/BazanAI.{Service}.Tests/ -v
+dotnet test tests/Integration/ -v
+cd src/Python/bazan-knowledge-rag && pytest tests/ -v
+
+# Security check
+trivy fs . --severity CRITICAL,HIGH
+dotnet build BazanAI.sln -c Release
+
+# MongoDB shell
+docker exec bazan-mongo-1 mongosh \
+  -u root -p ${MONGO_ROOT_PASSWORD} --authenticationDatabase admin
+
+# Redis shell
+docker exec bazan-redis redis-cli -a ${REDIS_PASSWORD}
+
+# Generate secrets
+openssl genrsa -out jwt_private.pem 2048
+openssl rsa -in jwt_private.pem -pubout -out jwt_public.pem
+openssl rand -hex 32   # PII encryption key or random secret
+```
+
+---
+
+## 6. Development Conventions
+
+### 6.1 C# Naming
+
+```csharp
+// Classes, Interfaces, Enums: PascalCase
+public class FarmerAggregate { }
+public interface IFarmerRepository { }
+
+// Methods, Properties: PascalCase
+// Async methods MUST end in Async — no exceptions
+public async Task<Farmer> FindByIdAsync(string id, CancellationToken ct = default) { }
+
+// Private fields: _camelCase
+private readonly IFarmerRepository _farmerRepository;
+
+// Local variables, parameters: camelCase
+var farmerId = command.FarmerId;
+
+// Constants: PascalCase
+private const int MaxOtpAttempts = 5;
+```
+
+### 6.2 Clean Architecture — Dependency Rules
+
+```
+Domain ← Application ← Infrastructure / API
+
+Domain:         No external deps. Entities, Value Objects, Domain Events.
+Application:    CQRS via MediatR. Depends only on Domain. Result<T> for errors.
+Infrastructure: Implements interfaces. MongoDB, Redis, RabbitMQ, HTTP clients.
+API:            Controllers, Program.cs, DI registration.
+```
+
+Hard violations — never do:
+- Application importing Infrastructure namespace
+- Domain importing anything outside `System.*`
+- Controller containing business logic
+
+### 6.3 Result\<T\> Pattern — Business Errors
+
+```csharp
+// Business errors → Result<T>
+// Infrastructure failures → throw exception
+public async Task<Result<string>> Handle(MyCommand cmd, CancellationToken ct)
+{
+    var existing = await _repo.FindAsync(cmd.Id, ct);
+    if (existing is not null)
+        return Result.Failure("already_exists", "Tài nguyên đã tồn tại");
+
+    return Result.Success(entity.Id);
+}
+```
+
+### 6.4 Logging — Structured Only
+
+```csharp
+// CORRECT
+logger.LogInformation("Farmer {FarmerId} from {Province} logged in", id, province);
+
+// WRONG — string interpolation loses structured logging
+logger.LogInformation($"Farmer {id} logged in");  // ❌
+
+// WRONG — PII in logs
+logger.LogInformation("Phone {Phone}", phoneNumber);  // ❌
+```
+
+### 6.5 Python — Type Hints & Logging
+
+```python
+# Type hints MANDATORY on all function signatures
+async def search(query: str, collection: str, limit: int = 5) -> list[SearchResult]:
+    ...
+
+# Structured logging — never f-string
+logger.info("search_completed", query_len=len(query), results=len(results))
+# NOT: logger.info(f"Found {len(results)}")  ❌
+```
+
+---
+
+## 7. Security Rules — Non-negotiable
+
+```
+NEVER commit to git:
+  *.pem, *.key, .env, anything named *secret* or *credential*
+
+NEVER log:
+  Phone numbers, OTP values, JWT tokens,
+  Passwords or hashes, Exact GPS coordinates
+
+ALWAYS use:
+  RS256 (asymmetric)      for JWT signing        — NEVER HS256
+  AES-256-GCM             for PII encryption     — NEVER AES-CBC
+  BCrypt cost ≥ 12        for passwords          — NEVER MD5/SHA256 bare
+  time-constant comparison for secret comparison  — NEVER ==
+  RandomNumberGenerator   for IVs and nonces     — NEVER sequential
+
+PII fields that must be AES-256-GCM encrypted before MongoDB:
+  ExternalIdentity.ProviderUserId (when provider = "phone_otp")
+  Farmer.FullName
+  Farmer.ZaloId
+
+GPS coordinates: round to 0.01° (~1km) — do NOT encrypt, only round.
+```
+
+---
+
+## 8. Key Domain Models
+
+### 8.1 Farmer — Multi-Provider Identity
+
+`phoneNumber` is **NOT** a root field. Phone lives inside `identities[]`.
+
+```csharp
+public class Farmer
+{
+    public string Id { get; private set; }
+    public string FullName { get; private set; }       // encrypted
+    public string? PrimaryEmail { get; private set; }
+    public ConsentRecord PrivacyConsent { get; private set; }
+    public IReadOnlyList<ExternalIdentity> Identities { get; private set; }
+
+    public static Farmer RegisterWithPhone(
+        string encryptedPhone, string fullName, ConsentRecord consent) { }
+
+    public static Farmer RegisterWithOAuth(
+        string provider, string providerUserId, string email, string fullName) { }
+
+    public Result LinkIdentity(ExternalIdentity newIdentity) { }
+
+    // Helper — use instead of querying phoneNumber directly
+    public string? GetPhone()
+        => Identities.FirstOrDefault(i => i.Provider == "phone_otp")?.ProviderUserId;
+}
+
+public record ExternalIdentity(
+    string Provider,         // "phone_otp" | "google" | "email_password"
+    string ProviderUserId,   // encrypted phone | google_uid | email
+    string? Email,
+    DateTime LinkedAt
+);
+
+public record ConsentRecord(
+    bool Accepted, DateTime AcceptedAt,
+    string PolicyVersion,    // e.g. "1.0.0"
+    string AcceptedFromIp
+);
+```
+
+### 8.2 MongoDB Indexes — Identity
+
+```javascript
+// CORRECT — identity-based constraint
+db.farmers.createIndex(
+  { "identities.provider": 1, "identities.providerUserId": 1 },
+  { unique: true, sparse: true, name: "idx_identity_provider_unique" }
+)
+
+// WRONG — phoneNumber is not a root field
+// db.farmers.createIndex({ "phoneNumber": 1 })  ❌
+```
+
+### 8.3 JWT Claims
+
+```json
+{
+  "sub": "farmerId",  "role": "farmer",
+  "farm_ids": ["..."], "province": "Dak Lak",
+  "jti": "uuid-v4",   "iss": "bazan-ai", "aud": "bazan-ai-services"
+}
+// NEVER include: phoneNumber, fullName, coordinates
+```
+
+### 8.4 Redis Key Naming
+
+```
+otp:{phoneNumber}              TTL 300s   — hashed OTP value
+otp_attempts:{phoneNumber}     TTL 900s   — integer attempt count
+blacklist:{jti}                TTL = token remaining expiry
+oauth_state:{nonce}            TTL 300s   — CSRF protection
+cache:price:{coffeeType}       TTL 300s
+cache:embedding:{sha256}       TTL 3600s
+```
+
+### 8.5 RabbitMQ Routing Key Format
+
+```
+Pattern: bazan.{domain}.{entity}.{action}
+
+Examples:
+  bazan.farmer.registered
+  bazan.farmer.location.updated
+  bazan.agronomy.disease.alert.generated
+  bazan.market.price.updated
+  bazan.iot.sensor.data.received
+  bazan.weather.alert.triggered
+  bazan.conversation.feedback.collected
+```
+
+---
+
+## 9. Testing Conventions
+
+| Layer | Coverage Target | Method |
+|-------|----------------|--------|
+| Domain | ≥ 90% | Unit tests |
+| Application | ≥ 80% | Unit tests |
+| Infrastructure | ≥ 60% | Integration tests |
+| Overall | ≥ 70% | CI gate |
+
+```csharp
+// Unit test naming: MethodName_WhenScenario_ExpectedResult
+// Mocking: NSubstitute  |  Assertions: FluentAssertions
+
+[Fact]
+public async Task Handle_WhenEntityNotFound_ReturnsFailure()
+{
+    // Arrange
+    _repo.FindByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+         .Returns((Entity?)null);
+    // Act
+    var result = await _sut.Handle(command, CancellationToken.None);
+    // Assert
+    result.IsSuccess.Should().BeFalse();
+}
+
+// Integration tests — always verify:
+// - BOLA: cross-tenant access returns 403
+// - PII roundtrip: encrypt → store → retrieve → decrypt → equals plaintext
+```
+
+---
+
+## 10. CI/CD Pipeline
+
+| Branch | Deploy | Gate |
+|--------|--------|------|
+| `feature/*`, `bugfix/*` | None | CI must pass |
+| `develop` | Staging (auto) | CI + smoke test |
+| `main` | Production (manual approval) | CI + full regression |
+
+CI gates in order:
+1. `dotnet build` (Release)
+2. Unit tests — coverage ≥ 70%
+3. Integration tests — TestContainers
+4. `pytest` — Python RAG
+5. `trivy fs` — zero CRITICAL vulns
+6. AI eval regression — only with `ai-change` label
+
+---
+
+## 11. Automated Developer Workflow
+
+**MANDATORY:** Create a GitHub issue before starting. Read the sprint spec before writing code.
+
+### Preparation
+
+```bash
+# Read sprint task specification
+cat docs/sprints/{sprint-file}.md
+
+# Check or create issue
+gh issue view {id}
+
+# Sync and branch
+git checkout develop && git pull origin develop
+git checkout -b feature/{id}-{short-desc}
+# e.g.: feature/42-multi-provider-identity
+# Rules: lowercase, kebab-case, include issue ID
+```
+
+### Before Writing Code
+
+- [ ] Sprint spec AC read completely
+- [ ] ADR consulted if touching architecture (`docs/architecture/ADR-*.md`)
+- [ ] Critical path dependencies in sprint spec checked
+- [ ] Security rules reviewed (Section 7)
+
+### Verify Before Commit
+
+```bash
+dotnet build BazanAI.sln -c Release
+dotnet test tests/Unit/ -v
+trivy fs . --severity CRITICAL,HIGH --exit-code 1
+
+# Verify no PII in logs — expected: zero results
+grep -rn "Log.*Phone\|Log.*phoneNumber\|Log.*otp\|Log.*password" src/ --include="*.cs"
+```
+
+### Commit Convention
+
+```bash
+# Format: {type}({scope}): {description}
+git commit -m "feat(identity): add multi-provider ExternalIdentity schema"
+git commit -m "fix(agronomy): correct disease threshold for TR4 variety"
+git commit -m "test(market): add integration test for geospatial buyer query"
+git commit -m "chore(infra): replace idx_phone_unique with idx_identity_provider"
+
+# Types:  feat | fix | refactor | test | docs | chore | perf | style | revert
+# Scopes: identity | agronomy | market | conversations | orchestrator |
+#         rag | notification | iot | weather | gateway | shared | infra | docs
+```
+
+### Pull Request
+
+```bash
+git push origin {branch-name}
+
+gh pr create \
+  --base develop \
+  --head {branch-name} \
+  --title "[TYPE-{ID}] Short description" \
+  --body "## Changes
+- List of changes
+
+## Related
+- Closes #{ID}
+
+## Checklist
+- [ ] Sprint spec AC verified
+- [ ] Unit tests added/updated
+- [ ] No PII in logs (grep verified)
+- [ ] No secrets hardcoded
+- [ ] Clean Architecture boundaries respected
+- [ ] Security-critical code reviewed by Engineering Lead
+- [ ] OpenAPI spec updated (if endpoint changed)"
+```
+
+### Merge
+
+```bash
+gh pr checks {pr-number}
+gh pr merge {pr-number} --squash --delete-branch
+git checkout develop && git pull origin develop
+```
+
+---
+
+## 12. Environment Variables Reference
+
+```bash
+# MongoDB
+MONGO_ROOT_USER=admin
+MONGO_ROOT_PASSWORD=<strong>
+
+# Redis
+REDIS_PASSWORD=<strong>
+
+# JWT — RS256 asymmetric
+JWT_PRIVATE_KEY_PATH=/run/secrets/jwt_private.pem
+JWT_PUBLIC_KEY_PATH=/run/secrets/jwt_public.pem
+JWT_ISSUER=bazan-ai
+JWT_AUDIENCE=bazan-ai-services
+
+# PII Encryption
+PII_ENCRYPTION_KEY=<32-byte hex>     # openssl rand -hex 32
+OTP_PEPPER=<32-char random>
+
+# Internal service-to-service
+SERVICE_API_KEY_ORCHESTRATOR=<32-char>
+SERVICE_API_KEY_AGRONOMY=<32-char>
+
+# External APIs
+OPENAI_API_KEY=sk-...
+ZALO_OA_ACCESS_TOKEN=...
+GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=GOCSPX-xxx
+TWILIO_ACCOUNT_SID=...
+TWILIO_AUTH_TOKEN=...
+OPENWEATHER_API_KEY=...
+ICE_FUTURES_API_KEY=...
+MINIO_ACCESS_KEY=...
+MINIO_SECRET_KEY=...
+```
+
+---
+
+## 13. Architectural Decisions (Summary)
+
+Read full ADRs in `docs/architecture/` when implementing related features.
+
+| ADR | Decision | Key constraint |
+|-----|---------|---------------|
+| ADR-001 | MongoDB primary DB | Replica Set required for transactions + Change Streams |
+| ADR-002 | Qdrant vector DB | Hybrid search: dense + BM42 sparse + RRF mandatory |
+| ADR-003 | RabbitMQ + MassTransit | Outbox pattern for reliability; idempotent consumers required |
+| ADR-004 | Semantic Kernel | AutoFunctionCalling; token budget enforced per conversation |
+| ADR-005 | YARP API Gateway | JWT validated at gateway; `X-Farmer-Id` forwarded to services |
+| ADR-006 | Offline-first mobile | 3-tier cache; client outbox for offline writes |
+
+---
+
+## 14. Permanent Schema Constraints
+
+These apply across all sprints. Violating them creates migration debt on live data.
+
+**Farmer schema — phone is NOT a root field:**
+```
+❌ db.farmers.phoneNumber = "+84..."
+✅ db.farmers.identities[{ provider: "phone_otp" }].providerUserId = "<encrypted>"
+```
+
+**ConsentRecord is mandatory when creating Farmer:**
+```
+Legal requirement per Nghị định 13/2023.
+Never create Farmer without a valid ConsentRecord.
+```
+
+**OAuth callback — never re-implement platform flow:**
+```
+ASP.NET Core AddGoogle() handles: redirect, code exchange, token verify, CSRF.
+Our callback only does: read User.Claims → upsert Farmer → issue JWT.
+Do not add code that re-implements what the middleware already does.
+```
+
+**Mobile stack is React Native — never Flutter:**
+```
+Secure storage:  react-native-keychain  (NOT AsyncStorage)
+Google OAuth:    @react-native-google-signin/google-signin
+Form handling:   react-hook-form + zod
+```
+
+---
+
+*For task requirements and acceptance criteria → `docs/sprints/{sprint}.md`*
+*For architectural rationale → `docs/architecture/ADR-*.md`*
+*This file covers permanent conventions only.*
+
+---
+
+## 15. AI Agent Operating Mode
+
+Gemini CLI operates as a **Senior Software Engineer** on this project. Default behavior is fully autonomous unless a decision is explicitly irreversible or high-risk.
+
+### Autonomy Levels
+
+| Situation | Behavior |
+|-----------|---------|
+| Implement sprint task | Fully autonomous — read spec, code, test, commit, PR |
+| Refactor within a service | Autonomous — no approval needed |
+| Add new file or class | Autonomous |
+| Modify shared kernel | Ask before proceeding — affects all services |
+| Schema migration on live data | Ask before proceeding — data loss risk |
+| Delete files | Ask before proceeding |
+| Change CI/CD pipeline | Ask before proceeding |
+| Merge to `main` | Always ask for explicit approval |
+| External API credentials | Never touch — ask human to provide |
+
+### Default Assumptions When Spec Is Ambiguous
+
+```
+Language not specified → C# for services, TypeScript for mobile
+Pattern not specified  → follow existing pattern in same service
+Test framework         → NSubstitute + FluentAssertions (C#), pytest (Python)
+Error handling         → Result<T> for business, throw for infrastructure
+Logging level          → Information for business events, Warning for retries
+```
+
+### Autonomous Decision Log
+
+After completing any task autonomously, append a summary to the PR description:
+
+```
+## Autonomous Decisions
+- Used X pattern because Y (spec did not specify)
+- Added Z index because query would COLLSCAN without it
+- Chose BCrypt cost 12 per GEMINI.md security rules
+```
+
+---
+
+## 16. GitHub Issue Execution Protocol
+
+When told "work on issue #X" or "implement task Y", execute this exact sequence without skipping steps.
+
+### Phase 1 — Understand (do not skip)
+
+```bash
+# 1. Read the issue
+gh issue view {id}
+
+# 2. Read the referenced sprint spec
+cat docs/sprints/{sprint-file}.md
+
+# 3. Read relevant ADR if architectural
+cat docs/architecture/ADR-{N}-{name}.md
+
+# 4. Read existing code in the service being modified
+# Do NOT assume — read before writing
+find src/Services/BazanAI.{Service} -name "*.cs" | head -20
+```
+
+### Phase 2 — Plan (state this out loud before coding)
+
+```
+Before writing code, output:
+  "PLAN:
+   - Files to create: [list]
+   - Files to modify: [list]
+   - Tests to write: [list]
+   - Dependencies / blockers: [list]
+   - Estimated risk: Low / Medium / High"
+```
+
+If risk is **High** (schema change, shared kernel, security) — pause and ask for confirmation.
+
+### Phase 3 — Implement
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b feature/{id}-{short-desc}
+
+# Implement in this order:
+# 1. Domain entities / value objects (no dependencies)
+# 2. Application commands / queries / handlers
+# 3. Infrastructure (repositories, clients)
+# 4. API (controllers, registrations)
+# 5. Tests (unit first, then integration)
+```
+
+### Phase 4 — Verify (all must pass)
+
+```bash
+dotnet build BazanAI.sln -c Release
+dotnet test tests/Unit/ -v
+dotnet test tests/Integration/ -v   # if DB/messaging touched
+trivy fs . --severity CRITICAL,HIGH --exit-code 1
+grep -rn "Log.*Phone\|Log.*phoneNumber\|Log.*otp" src/ --include="*.cs"
+# Above grep must return zero results
+```
+
+### Phase 5 — Ship
+
+```bash
+git push origin {branch}
+gh pr create --base develop --head {branch} --title "[FEAT-{id}] ..." --body "..."
+gh pr checks {pr-number}   # wait for CI
+# Then ask human: "PR #{number} is ready. Approve to merge?"
+```
+
+---
+
+## 17. Multi-Role Simulation
+
+Gemini CLI switches roles at defined points in the workflow. Each role has a distinct mindset.
+
+### Role 1 — Developer 🛠
+
+**Active during:** Phase 3 (Implement)
+
+Mindset: "Make it work correctly, follow the spec exactly."
+
+```
+Rules:
+  - Implement only what the AC specifies — no gold-plating
+  - Follow Clean Architecture boundaries strictly
+  - Write just enough code to pass all AC
+  - Leave no TODO comments without a linked issue
+```
+
+### Role 2 — Reviewer 🔍
+
+**Active during:** Phase 4 (Verify), before creating PR
+
+Mindset: "Would I approve this PR if someone else wrote it?"
+
+```
+Reviewer checklist — read diff as if seeing it for the first time:
+
+Security:
+  □ No PII in logs
+  □ No hardcoded secrets
+  □ Cryptography uses correct algorithms (RS256, AES-256-GCM, BCrypt)
+  □ Authorization check at resource level, not only role level
+
+Architecture:
+  □ No Clean Architecture boundary violations
+  □ No business logic in controllers
+  □ Result<T> for business errors, not exceptions
+
+Quality:
+  □ No dead code or commented-out blocks
+  □ No magic numbers — all constants named
+  □ Method length ≤ 30 lines (if longer, extract)
+  □ All public methods have XML doc comments
+
+Tests:
+  □ Happy path covered
+  □ Error cases covered
+  □ Edge cases covered (null, empty, boundary values)
+  □ No test that always passes (assert something meaningful)
+```
+
+If any box is unchecked → fix before creating PR, not after.
+
+### Role 3 — QA 🧪
+
+**Active during:** After PR is merged to staging
+
+Mindset: "Does this actually work end-to-end from a farmer's perspective?"
+
+```
+QA verification steps:
+  1. Hit the endpoint manually via Postman collection (docs/postman/)
+  2. Verify Seq logs: no PII, correct structured fields
+  3. Verify MongoDB: data persisted correctly (including encryption)
+  4. Verify event published to RabbitMQ (if applicable)
+  5. Verify downstream consumers received the event
+
+If QA fails → create a bugfix issue immediately, do not close the feature issue.
+```
+
+---
+
+## 18. Code Generation Rules
+
+Rules that prevent breaking existing structure when generating new code.
+
+### Never Break These
+
+```
+1. SharedKernel public interfaces
+   — Any change to IFarmerRepository, Result<T>, base entities
+   → affects ALL services. Ask before changing.
+
+2. MongoDB document schemas with live data
+   — Adding a required field without default value → all existing documents break
+   → Always add new fields as optional (?) with a default value first
+
+3. RabbitMQ event contracts
+   — Removing or renaming fields in published events → consumer breaks
+   → Events are append-only. Never remove fields. Deprecate with [Obsolete] first.
+
+4. JWT claim names
+   — "sub", "role", "farm_ids", "province", "jti"
+   → Renaming a claim breaks Gateway + all services simultaneously
+
+5. Public API response fields
+   — Removing a field breaks mobile clients
+   → Follow API versioning — add to new version, don't remove from current
+```
+
+### File Creation Rules
+
+```
+New service file placement:
+  Domain entity          → BazanAI.{Service}.Domain/Entities/
+  Value object           → BazanAI.{Service}.Domain/ValueObjects/
+  Domain event           → BazanAI.{Service}.Domain/Events/
+  Command / Query        → BazanAI.{Service}.Application/Commands/ or /Queries/
+  Command Handler        → same folder as Command, named {Command}Handler.cs
+  Repository interface   → BazanAI.{Service}.Domain/Repositories/
+  Repository impl        → BazanAI.{Service}.Infrastructure/Persistence/
+  Controller             → BazanAI.{Service}.API/Controllers/
+  Unit test              → tests/Unit/BazanAI.{Service}.Tests/
+  Integration test       → tests/Integration/BazanAI.{Service}.IntegrationTests/
+
+One class per file. File name = class name. No exceptions.
+```
+
+### Code Modification Rules
+
+```
+Before modifying an existing file:
+  1. Read the full file — understand all existing methods
+  2. Check if a base class in SharedKernel already provides the behavior
+  3. Prefer extending over modifying if the class is used by multiple services
+
+When adding a method to an existing class:
+  1. Place it in logical order (public before private, CRUD in CRUD order)
+  2. Follow the naming pattern of existing methods in the same file
+  3. Add XML doc comment if the class already has them
+
+When adding a new dependency:
+  1. Check if the same library is already in another service's .csproj
+  2. Use the same version — never introduce a different version of the same package
+```
+
+---
+
+## 19. Branch & Commit Enforcement
+
+### Branch Rules
+
+```
+Allowed branches:
+  feature/{issue-id}-{kebab-desc}    e.g. feature/42-multi-provider-identity
+  bugfix/{issue-id}-{kebab-desc}     e.g. bugfix/55-otp-rate-limit-reset
+  hotfix/{issue-id}-{kebab-desc}     e.g. hotfix/71-jwt-expiry-timezone
+  chore/{description}                e.g. chore/update-nuget-packages
+  docs/{description}                 e.g. docs/update-rag-pipeline-spec
+
+Forbidden:
+  Branching from main directly (use develop)
+  Branch names without issue ID (except chore/ and docs/)
+  Working on develop directly
+  Reusing a branch after it has been merged
+```
+
+### Commit Rules
+
+```bash
+# Format: {type}({scope}): {imperative description}
+# Description: present tense, no period, max 72 chars
+
+# Types
+feat     — new feature
+fix      — bug fix
+refactor — code change that neither fixes bug nor adds feature
+test     — adding or updating tests
+docs     — documentation only
+chore    — build process, dependencies, CI
+perf     — performance improvement
+style    — formatting only (no logic change)
+revert   — reverts a previous commit
+
+# Scopes — match service name
+identity | agronomy | market | conversations | orchestrator |
+rag | notification | iot | weather | gateway | shared | infra | docs
+
+# Good examples
+feat(identity): add Google OAuth callback handler
+fix(agronomy): correct TR4 disease threshold calculation
+test(market): add BOLA test for buyer geo-search endpoint
+chore(infra): replace phoneNumber index with identity provider index
+
+# Bad examples — do not use
+git commit -m "fix bug"                   ❌ no scope, no description
+git commit -m "WIP"                       ❌ never commit WIP
+git commit -m "feat: add stuff"           ❌ no scope
+git commit -m "FEAT(Identity): Add Auth"  ❌ wrong case
+```
+
+### Commit Atomicity
+
+```
+Each commit must be independently deployable and meaningful.
+
+Good:  1 commit = "feat(identity): add ExternalIdentity domain model"
+       1 commit = "test(identity): add unit tests for RegisterWithPhone"
+
+Bad:   1 commit = "add identity stuff, fix tests, update db" ❌
+       Mix of feat + test + fix in one commit ❌
+```
+
+---
+
+## 20. Self-Review Checklist
+
+Run this checklist mentally before creating any PR. If any item fails, fix it first.
+
+### Architecture
+
+```
+□ Clean Architecture boundaries not violated
+  (Application does not import Infrastructure namespace)
+□ No business logic in API controllers
+□ Domain entities do not have public setters
+□ All dependencies injected via constructor (no service locator)
+□ New interfaces added to Domain or Application layer, not Infrastructure
+```
+
+### Security
+
+```
+□ No PII (phone, name, GPS, OTP, token) appears in any log call
+□ No secret, key, or password hardcoded in any file
+□ No .env, .pem, or .key file staged for commit
+  (run: git diff --cached --name-only | grep -E "\.env|\.pem|\.key")
+□ Cryptography uses project-standard algorithms (Section 7)
+□ Authorization checked at resource level, not just endpoint level
+□ Input validated before reaching business logic (FluentValidation)
+```
+
+### Data Integrity
+
+```
+□ New MongoDB fields are nullable or have default values
+  (no required fields added without migration plan)
+□ RabbitMQ events only have fields added, never removed
+□ Public API responses only have fields added, never removed
+□ Farmer.phoneNumber not referenced as root field anywhere in new code
+□ ConsentRecord included when creating Farmer
+```
+
+### Tests
+
+```
+□ Every new public method in Application layer has at least 1 unit test
+□ Every new endpoint has at least 1 integration test
+□ Test coverage has not decreased (run coverage report)
+□ No test uses Thread.Sleep — use mocked time or async waits
+□ All test assertions are meaningful (not just Assert.True(true))
+```
+
+### Ops
+
+```
+□ New service dependencies added to docker-compose.yml if needed
+□ New environment variables added to .env.example with comments
+□ OpenAPI spec updated if any endpoint was added or changed
+□ New Hangfire jobs registered in Program.cs scheduler
+```
+
+---
+
+## 21. Failure Handling Rules
+
+What to do when things go wrong during task execution.
+
+### Build Failure
+
+```
+1. Read the full error — do not guess
+2. Fix only the reported error — do not refactor unrelated code
+3. Re-run build to confirm fix
+4. If failure is in SharedKernel → stop and ask before continuing
+   (SharedKernel changes affect all services)
+```
+
+### Test Failure
+
+```
+1. Read the failing assertion — understand what it expected vs got
+2. Determine cause: wrong implementation OR wrong test?
+   - If implementation is wrong → fix implementation
+   - If test assumption was wrong → fix test AND document why
+3. Never delete a failing test — fix it or create a tracking issue
+4. Never add [Ignore] or [Skip] without a comment explaining why
+```
+
+### CI Failure on PR
+
+```
+1. Run gh pr checks {pr-number} to see which check failed
+2. Pull the branch and reproduce locally
+3. Fix and push — CI re-runs automatically
+4. If Trivy finds a CRITICAL vulnerability in a dependency:
+   a. Check if newer version is available
+   b. Update the package
+   c. Re-run tests to ensure compatibility
+   d. If no fix available → document in PR and ask human to decide
+```
+
+### Merge Conflict
+
+```
+1. Always rebase onto develop — never merge develop into feature branch
+   git fetch origin && git rebase origin/develop
+2. Resolve conflict by understanding BOTH changes:
+   - Read git log of the conflicting commit
+   - Understand what the other change was doing
+   - Merge semantically, not textually
+3. After conflict resolution: run full test suite before pushing
+4. If conflict is in SharedKernel or critical path → ask human to review resolution
+```
+
+### Runtime Error on Staging
+
+```
+1. Check Seq logs first (SSH tunnel: ssh -L 5341:localhost:5341 deploy@staging)
+2. Find the CorrelationId from the error response
+3. Search Seq: CorrelationId = "{id}"  — this traces the full request
+4. If data corruption suspected → do NOT run more requests
+   Stop and assess before proceeding
+5. Create a bugfix issue immediately with:
+   - Error message
+   - CorrelationId
+   - Steps to reproduce
+   - Suspected root cause
+```
+
+### Blocked by Dependency
+
+```
+If a task cannot start because a dependency is not complete:
+  1. Comment on the GitHub issue: "Blocked by #X — {dependency task}"
+  2. Check if any subtask can be done in isolation
+  3. Write tests for the blocked feature using mocks
+     (tests can be written before implementation)
+  4. Ask human to reprioritize if blocking critical path
+```
+
+---
+
+## 22. Multi-Service Awareness
+
+Before implementing any task, identify which services are involved.
+
+### Service Interaction Map
+
+```
+Request enters: Gateway (8080)
+    │
+    ├── Auth requests → Identity (5001)
+    ├── Chat requests → Orchestrator (5010) ──► Knowledge RAG (5003)
+    │                                       ──► Agronomy (5004)
+    │                                       ──► Market (5005)
+    │                                       ──► Weather (5008)
+    ├── Market data   → Market (5005)
+    ├── Agronomy data → Agronomy (5004)
+    ├── Sensor data   → IoT (5007) ──► RabbitMQ ──► Agronomy, Identity
+    └── Files         → Media (5009) ──► MinIO
+                                     ──► Agronomy (CV model)
+
+Events flow via RabbitMQ:
+  Identity  ──publishes──► FarmerRegistered, LocationUpdated
+  Agronomy  ──publishes──► DiseaseAlertGenerated, IrrigationReminderCreated
+  Market    ──publishes──► PriceUpdated
+  IoT       ──publishes──► SensorDataReceived
+  Weather   ──publishes──► WeatherAlertTriggered
+```
+
+### Cross-Service Change Impact Assessment
+
+Before modifying any service, check:
+
+```
+Modifying Identity Service?
+  → Gateway depends on JWT claims format
+  → Orchestrator calls /farmers/{id}/context
+  → All services validate JWT with Identity's public key
+  → Test: does Gateway still route correctly after change?
+
+Modifying SharedKernel?
+  → ALL services are affected
+  → Run full test suite: dotnet test BazanAI.sln
+  → Do not merge without all services building and passing
+
+Modifying RabbitMQ event contracts?
+  → Identify all consumers in RabbitMQ Event Catalog (docs/api/)
+  → Add new fields only — never remove or rename
+  → Update all consumer handlers before publishing new field
+
+Modifying Gateway YARP routing?
+  → Test all routes after change
+  → Verify JWT validation still blocks unauthorized requests
+  → Verify rate limiting still applies
+```
+
+### Service Call Patterns
+
+```csharp
+// Service calling another service — always use typed HTTP client
+// Registered in DI: services.AddHttpClient<IAgronomyServiceClient, AgronomyServiceClient>()
+
+// Always pass CancellationToken — never fire-and-forget in request pipeline
+var result = await _agronomyClient.DiagnoseAsync(farmId, symptoms, ct);
+
+// Always apply Polly circuit breaker for external service calls
+// Config in SharedKernel/Extensions/PollyExtensions.cs
+
+// Internal service calls use X-Service-Api-Key header, NOT JWT
+// Never forward a farmer's JWT to another internal service
+```
+
+---
+
+## 23. AI/RAG Integration Rules
+
+Rules for working on Orchestrator, Knowledge RAG, and any AI-related code.
+
+### Semantic Kernel — Plugin Rules
+
+```csharp
+// Plugin methods must be:
+// 1. Async
+// 2. Return string (LLM reads text, not objects)
+// 3. Have [KernelFunction] and [Description] attributes
+// 4. Description must explain WHEN to call this, not just what it does
+
+[KernelFunction("get_disease_diagnosis")]
+[Description("Call this when farmer describes plant symptoms or uploads a disease photo. Returns diagnosis with treatment plan. Do NOT call for general farming questions.")]
+public async Task<string> GetDiseaseDiagnosis(
+    [Description("Farm ID of the affected farm")] string farmId,
+    [Description("Symptom description in Vietnamese or English")] string symptoms)
+{
+    var result = await _agronomyClient.DiagnoseAsync(farmId, symptoms);
+    // Return concise text — NOT full JSON object (wastes tokens)
+    return $"Bệnh: {result.DiseaseName} (confidence: {result.Confidence:P0})\n" +
+           $"Phác đồ: {result.Treatment}\nNguồn: {result.SourceDocument}";
+}
+
+// Plugin return values must be under 500 tokens
+// Never return raw API responses or full document content
+```
+
+### Prompt Rules
+
+```
+Prompt files location: src/Services/BazanAI.Orchestrator/Prompts/v{N}/
+
+Version prompts — never edit in place:
+  v1/system.txt  → current production
+  v2/system.txt  → next version (A/B test or staged rollout)
+
+Never hardcode prompts in C# strings.
+Never include PII in prompts — use pseudonyms or role descriptions.
+
+Token budget per conversation (enforced in code):
+  System prompt:    1,200 tokens max
+  Farmer context:     300 tokens max
+  Conversation history: 2,000 tokens max
+  RAG retrieved:    2,000 tokens max
+  User query:         200 tokens max
+  Total:            5,700 tokens max
+```
+
+### RAG Pipeline Rules
+
+```python
+# Hybrid search is mandatory — never pure dense or pure sparse
+results = await qdrant_client.query_points(
+    collection_name=collection,
+    prefetch=[
+        Prefetch(query=dense_vector, using="dense", limit=20),
+        Prefetch(query=sparse_vector, using="sparse", limit=20),
+    ],
+    query=FusionQuery(fusion=Fusion.RRF),
+    with_payload=True,
+    limit=5,
+)
+
+# Always apply payload filter before search — reduces search space
+# Filter on: coffee_varieties, region, growth_stages, language, is_deprecated=false
+
+# Never index without metadata annotation
+# Required fields: coffee_varieties, topics, region, language, source_year, document_type
+# Never index a document where is_deprecated=True would apply
+```
+
+### Safety Rules for AI Output
+
+```
+Before returning any AI response to the client:
+  1. Check for banned chemicals (hardcoded list — never LLM-dependent)
+  2. Verify response contains citation when making technical claims
+  3. Confidence score included for any disease diagnosis
+  4. If AI response would recommend a dosage > 150% of label → intercept and flag
+
+Banned chemical check must run in code, not in prompt:
+  // In OrchestratorService.ValidateAiResponse()
+  foreach (var banned in BannedChemicals.List)
+      if (response.Contains(banned, StringComparison.OrdinalIgnoreCase))
+          return SafetyViolationResult(banned);
+```
+
+---
+
+## 24. Definition of Done
+
+A task is **Done** only when ALL of the following are true. Partial completion is not Done.
+
+### Code Complete
+
+```
+□ All Acceptance Criteria from sprint spec pass
+□ No TODO comments without linked GitHub issue
+□ No commented-out code blocks
+□ No unused using statements or imports
+□ All new public methods have XML doc comments (C#) or docstrings (Python)
+```
+
+### Tests Pass
+
+```
+□ Unit tests: all pass, coverage not decreased
+□ Integration tests: all pass (if DB/messaging touched)
+□ No test marked [Ignore] or [Skip] without explanation
+□ CI pipeline: all checks green
+```
+
+### Security Verified
+
+```
+□ Trivy scan: zero CRITICAL vulnerabilities
+□ PII grep: zero results
+   grep -rn "Log.*Phone\|Log.*phoneNumber\|Log.*otp" src/ --include="*.cs"
+□ No secrets in git diff
+   git diff --cached --name-only | grep -E "\.env|\.pem|\.key|secret|credential"
+□ Security-critical tasks signed off by Engineering Lead (see sprint spec)
+```
+
+### Documentation Updated
+
+```
+□ OpenAPI spec updated (if endpoint added/changed/removed)
+□ CHANGELOG.md updated (for user-facing changes)
+□ .env.example updated (if new environment variable added)
+□ README or architecture doc updated (if new service or major change)
+```
+
+### Deployed & Verified
+
+```
+□ Deployed to staging (auto on develop merge)
+□ Smoke test passes (make health)
+□ Seq logs: no unexpected errors in 15 minutes post-deploy
+□ QA role verification completed (Section 17)
+```
+
+---
+
+## 25. Forbidden Actions
+
+These actions are absolutely prohibited. If a situation seems to require one of these, stop and ask the human.
+
+### Code
+
+```
+❌ Delete or rename a field from a published RabbitMQ event
+❌ Add a required non-nullable field to an existing MongoDB collection without migration
+❌ Change JWT claim names (sub, role, farm_ids, province, jti)
+❌ Remove or rename a public API endpoint without versioning
+❌ Implement custom cryptography — use only .NET/Python standard libraries
+❌ Disable or bypass the PII masking Serilog policy
+❌ Return stack traces in API error responses
+❌ Use Thread.Sleep in production code
+❌ Call another service's database directly — only via HTTP API
+❌ Store secrets in appsettings.json or any committed file
+```
+
+### Git
+
+```
+❌ Force push to develop or main
+❌ Commit directly to develop or main
+❌ Merge without CI passing
+❌ Squash commits that have already been reviewed and approved
+❌ Add .env, .pem, .key, or any secret file to any commit
+❌ Rewrite git history on a shared branch
+```
+
+### AI / Prompts
+
+```
+❌ Include real farmer PII (phone, name, GPS) in any prompt sent to OpenAI
+❌ Bypass the banned chemicals check in AI response validation
+❌ Return AI-generated content without a citation when making technical claims
+❌ Change prompt files in-place — always create a new versioned file
+❌ Remove the token budget enforcement from Orchestrator
+```
+
+### Process
+
+```
+❌ Close a GitHub issue without all AC verified
+❌ Merge a PR that fails any CI check
+❌ Skip the Self-Review Checklist (Section 20)
+❌ Create a PR to main without explicit human approval
+❌ Deploy to production without passing staging smoke test
+```
+
+---
+
+## 26. Execution Priority Rules
+
+When multiple tasks compete for attention or a situation is ambiguous, apply these rules in order.
+
+### Priority 1 — Safety (always first)
+
+```
+If any action could expose PII, introduce a security vulnerability,
+or corrupt live data → STOP and ask the human before proceeding.
+
+This overrides sprint deadlines, feature requests, and any other rule.
+```
+
+### Priority 2 — Correctness over Speed
+
+```
+A slow correct implementation > a fast broken one.
+
+If the sprint spec AC and the implementation approach conflict:
+  → Follow the AC, not the approach
+  → Document the deviation in the PR
+
+If unsure whether implementation is correct:
+  → Write the test first, then implement until the test passes
+```
+
+### Priority 3 — Spec over Assumption
+
+```
+If sprint spec says X but this file says Y:
+  → Sprint spec wins for that specific task
+  → Note the conflict in PR description
+
+If neither spec nor this file addresses a situation:
+  → Follow the pattern established in the existing codebase
+  → Document the decision in the PR
+```
+
+### Priority 4 — Existing Patterns over New Patterns
+
+```
+Before introducing a new pattern or library:
+  1. Search the codebase for how similar problems are solved
+  2. Use the existing solution unless there is a clear documented reason not to
+  3. If introducing something new → document why in ADR or PR description
+```
+
+### Priority 5 — Incremental Delivery
+
+```
+Prefer shipping a smaller working increment over a large incomplete one.
+
+If a task is too large to complete in one PR:
+  1. Identify the minimum slice that delivers value
+  2. Create sub-issues for remaining work
+  3. Ship the first slice, reference sub-issues in PR
+  4. Never merge code that leaves the system in a broken intermediate state
+```
+
+### Conflict Resolution Matrix
+
+| Conflict | Resolution |
+|---------|-----------|
+| Sprint spec vs GEMINI.md | Sprint spec wins |
+| This file vs existing code pattern | This file wins (code may be outdated) |
+| Speed vs correctness | Correctness always |
+| New library vs existing pattern | Existing pattern (ask to justify new) |
+| Autonomy vs data safety | Always ask for data-affecting changes |
+| CI failing vs deadline | Fix CI — never merge a failing build |
+
+---
+
+*Version: 3.0.0 | Updated: 2026-03-19*


### PR DESCRIPTION
## Changes
- Implemented `IOtpService` for generating and hashing OTPs.
- Integrated `ZaloClient` for sending OTPs via Zalo OA message API.
- Added `SendOtpCommand` and Handler in the Application layer.
- Configured Redis for OTP storage with a 5-minute TTL.
- Updated `.env.example` with Zalo and OTP security settings.

## Checklist
- [x] AC-A1-02: OTP not returned in response.
- [x] AC-A1-03: OTP not logged in plaintext.
- [x] AC-A1-04: Phone number validation (regex match).